### PR TITLE
Shelvery 0.5.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,3 +8,4 @@ v0.4.1, 27/04/2018 -- Updating scm repository information, no source code change
 v0.4.2, 27/04/2018 -- RDS and Cluster - fallback to regular snapshot if no automated backups. Bugfix - backup cleanup
                       when resource is not available.
 v0.4.3, 27/04/2018 -- Bugfix - unmarking rds snapshots as shelvery managed
+v0.5.0, 21/08/2018 -- New features - Pull shared backups

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ It currently supports following resource types
 - RDS Instances
 - RDS Clusters
 
+Basic functionality includes
+
 Shelvery tries to make distinction in space of aws backup tools by *unifying backup and retention periods logic*
-within single class called `ShelveryEngine` - `shelvery/engine.py`. Also, most of the tools on the market allow
+within single class called `ShelveryEngine` - `shelvery/engine.py`. It differentiates itself from tooling that only allows 
 linear retention periods (e.g. 28days), whereas shelvery enables father-son-grandson backup strategy, effectively
 enabling it's users to "keep last 7 daily backups, but also last 12 monthly backups, created on 1st of each month"
 Supported levels of retention are - daily, weekly (created on Sundays), monthly (created 1st of each month), and yearly
@@ -27,6 +29,7 @@ Shelvery *does not* cater for backup restore process.
 - Create and clean RDS Cluster backups
 - Create and clean EC2 Instance backups in form of Amazon Machine Images.
 - Share backups with other accounts automatically
+- Copying backups shared by other AWS accounts automatically 
 - Copy backups to disaster recovery AWS regions
 - Multiple levels of configuration, with priorities: Resource tags, Lambda payload, Environment Variables, Config defaults
 
@@ -246,6 +249,9 @@ Available configuration keys are listed below:
 - `shelvery_wait_snapshot_timeout` - Timeout in seconds to wait for snapshot to become available before copying it
 to another region or sharing with other account. Defaults to 1200 (20 minutes)
 - `shelvery_share_aws_account_ids` -  AWS Account Ids to share backups with. Applies to both original and regional backups                                                                   
+- `shelvery_source_aws_account_ids` - List of AWS Account Ids, comma seperated, that are exposing/sharing their shelvery
+    backups with account where shelvery is running. This can be used for having DR aws account that aggregates backups
+    from other accounts. 
 - `shelvery_rds_backup_mode` - can be either `RDS_COPY_AUTOMATED_SNAPSHOT` or `RDS_CREATE_SNAPSHOT`. Values are self-explanatory
 - `shelvery_lambda_max_wait_iterations` - maximum number of chained calls to wait for backup availability
 when running Lambda environment. `shelvery_wait_snapshot_timeout` will be used only in CLI mode, while this key is used only
@@ -253,6 +259,10 @@ on Lambda
 
 - `shelvery_select_entity` - select only single resource to be backed up, rather than all tagged with shelvery tags. 
 This resource still needs to have shelvery tag on it to be backed up. 
+
+- `shelvery_sns_topic` - SNS Topic to publish event messages, including error messages for failed
+backups
+- `shelvery_source_aws_account_ids` - Comma-separated list of AWS account ids to pull backups from
 
 ### Configuration Priority 0: Sensible defaults
 
@@ -298,3 +308,30 @@ will ensure it's daily backups are retained for 30 days, and copied to `us-west-
 `shelvery:config:shelvery_dr_regions=us-west-1,us-west-2`
 
 Generic format for shelvery config tag is `shevlery:config:$configkey=$configvalue`
+
+
+## Multi account setup
+
+Shelvery allows setting up disaster recovery AWS account with 
+all of the backups from organisations AWS accounts copied to 
+'disaster recovery' account. 
+
+1) Sharing backups with other accounts
+
+```bash
+# this runs in every 
+# running in account 222222222222,333333333333
+$ export AWS_DEFAULT_PROFILE=source_account
+$ export shelvery_share_aws_account_ids=111111111111
+$ shelvery ebs create_backups
+```
+
+2) Copying shared backups from other acccount into current account
+
+```bash
+# this is running in destination account, let's say 111111111111
+$ export AWS_DEFAULT_PROFILE=dst_account
+$ export shelvery_source_aws_account_ids=222222222222,333333333333
+# this command will pull backups from both accounts
+$ shelvery ebs pull_shared_backups
+```

--- a/README.md
+++ b/README.md
@@ -216,8 +216,7 @@ tagging condition still applies.
 
 ### EC2
 
-EBS Backups in form of EBS Snapshots is supported. Support for EC2 instances backup in the form
-of AMIs is on the roadmap.
+EBS Backups in form of EBS Snapshots is supported. EC2 Instance backups in form of Amazon Machine Images (AMIs) is supported as well.
 
 ### RDS
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python-dateutil
 boto3
 pytest
+pyyaml

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-setup(name='shelvery', version='0.4.4', author='Base2Services R&D',
+setup(name='shelvery', version='0.5.0', author='Base2Services R&D',
       author_email='itsupport@base2services.com',
       url='http://github.com/base2Services/shelvery-aws-backups',
       classifiers=[
@@ -13,7 +13,7 @@ setup(name='shelvery', version='0.4.4', author='Base2Services R&D',
       ],
       keywords='aws backup lambda ebs rds ami',
       packages=['shelvery', 'shelvery_cli', 'shelvery_lambda'],
-      install_requires=['boto3', 'python-dateutil'],
+      install_requires=['boto3', 'python-dateutil', 'pyyaml'],
       python_requires='>=3.6',
       description='Backup manager for AWS EBS and AWS RDS services',
       entry_points={

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-setup(name='shelvery', version='0.4.3', author='Base2Services R&D',
+setup(name='shelvery', version='0.4.4', author='Base2Services R&D',
       author_email='itsupport@base2services.com',
       url='http://github.com/base2Services/shelvery-aws-backups',
       classifiers=[

--- a/shelvery/__init__.py
+++ b/shelvery/__init__.py
@@ -1,1 +1,4 @@
-__version__ = '0.4.2'
+__version__ = '0.5.0'
+LAMBDA_WAIT_ITERATION = 'lambda_wait_iteration'
+S3_DATA_PREFIX = 'backups'
+SHELVERY_DO_BACKUP_TAGS = ['True', 'true', '1', 'TRUE']

--- a/shelvery/aws_helper.py
+++ b/shelvery/aws_helper.py
@@ -1,0 +1,52 @@
+import json
+import boto3
+from shelvery import S3_DATA_PREFIX
+
+
+class AwsHelper:
+    
+
+    @staticmethod
+    def get_shelvery_bucket_policy(owner_id, share_account_ids, bucket_name):
+        """
+        Returns bucket policy allowing all destination accounts access to shared
+        paths
+        :param share_account_ids:
+        :param bucket_name:
+        :return:
+        """
+        policy_stmt = [{
+            'Effect': 'Allow',
+            'Principal':{'AWS':f"arn:aws:iam::{owner_id}:root"} ,
+            'Action': ['s3:*'],
+            'Resource': [
+                f"arn:aws:s3:::{bucket_name}",
+                f"arn:aws:s3:::{bucket_name}/*",
+            ]
+        }]
+        for shared_account_id in share_account_ids:
+            policy_stmt.append({
+                'Effect': 'Allow',
+                'Principal':{'AWS':f"arn:aws:iam::{shared_account_id}:root"} ,
+                'Action': ['s3:Get*', 's3:List*'],
+                'Resource': [
+                    f"arn:aws:s3:::{bucket_name}",
+                ]
+            })
+            policy_stmt.append({
+                'Effect': 'Allow',
+                'Principal':{'AWS':f"arn:aws:iam::{shared_account_id}:root"} ,
+                'Action': ['s3:*'],
+                'Resource': [
+                    f"arn:aws:s3:::{bucket_name}/{S3_DATA_PREFIX}/shared/{shared_account_id}*",
+                ]
+            })
+        return json.dumps({'Version': '2012-10-17', 'Id': 'shelvery-generated', 'Statement': policy_stmt})
+
+    @staticmethod
+    def local_account_id():
+        return boto3.client('sts').get_caller_identity()['Account']
+
+    @staticmethod
+    def local_region():
+        return boto3.session.Session().region_name

--- a/shelvery/ebs_backup.py
+++ b/shelvery/ebs_backup.py
@@ -60,7 +60,7 @@ class ShelveryEBSBackup(ShelveryEC2Backup):
     def get_backup_resource(self, region: str, backup_id: str) -> BackupResource:
         ec2 = boto3.session.Session(region_name=region).resource('ec2')
         snapshot = ec2.Snapshot(backup_id)
-        d_tags = dict(map(lambda t: (t['Key'], t['Value']), snapshot.tags));
+        d_tags = dict(map(lambda t: (t['Key'], t['Value']), snapshot.tags))
         return BackupResource.construct(d_tags['shelvery:tag_name'], backup_id, d_tags)
     
     def get_entities_to_backup(self, tag_name: str) -> List[EntityResource]:
@@ -107,7 +107,13 @@ class ShelveryEBSBackup(ShelveryEC2Backup):
                                   },
                                   UserIds=[aws_account_id],
                                   OperationType='add')
-    
+
+    def copy_shared_backup(self, source_account: str, source_backup: BackupResource):
+        snap = self.ec2client.copy_snapshot(
+            SourceSnapshotId=source_backup.backup_id,
+            SourceRegion=source_backup.region
+        )
+        return snap['SnapshotId']
     # collect all volumes tagged with given tag, in paginated manner
     def collect_volumes(self, tag_name: str):
         load_volumes = True

--- a/shelvery/ec2ami_backup.py
+++ b/shelvery/ec2ami_backup.py
@@ -97,19 +97,20 @@ class ShelveryEC2AMIBackup(ShelveryEC2Backup):
 
     @staticmethod
     def _convert_instances_to_entities(instances):
+        """
+        Params:
+            instances: a list of Reservations (i.e. the response from `aws ec2 describe-instances`)
+        """
         local_region = boto3.session.Session().region_name
-        entities = reduce(
-            # reduce function
-            lambda x, y: x + list(map(lambda z: EntityResource(
-                resource_id=z['InstanceId'],
-                resource_region=local_region,
-                date_created=z['LaunchTime'],
-                tags=dict(map(lambda x: (x['Key'], x['Value']), z['Tags']))
-            ), y['Instances'])),
-            # input list
-            list(map(lambda x: x, instances['Reservations'])),
-            # starting input
-            [])
+
+        entities = []
+        for reservation in instances['Reservations']:
+            for instance in reservation['Instances']:
+                tags = {}
+                if 'Tags' in instance:
+                    tags = dict(map(lambda tag: (tag['Key'], tag['Value']), instance['Tags']))
+                entities.append(EntityResource(resource_id=instance['InstanceId'], resource_region=local_region, date_created=instance['LaunchTime'], tags=tags))
+
         return entities
 
     def is_backup_available(self, backup_region: str, backup_id: str) -> bool:

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -3,32 +3,40 @@ import logging
 import time
 import sys
 
+import botocore
+import yaml
+import boto3
+from botocore.exceptions import ClientError
+from datetime import datetime
+
 from typing import List, Dict
 from abc import abstractmethod
 from abc import abstractclassmethod
 
+from shelvery.notifications import ShelveryNotification
+from shelvery.aws_helper import AwsHelper
 from shelvery.shelvery_invoker import ShelveryInvoker
 from shelvery.runtime_config import RuntimeConfig
 from shelvery.backup_resource import BackupResource
 from shelvery.entity_resource import EntityResource
 
-LAMBDA_WAIT_ITERATION = 'lambda_wait_iteration'
-
-SHELVERY_DO_BACKUP_TAGS = ['True', 'true', '1', 'TRUE']
+from shelvery import LAMBDA_WAIT_ITERATION
+from shelvery import S3_DATA_PREFIX
+from shelvery import SHELVERY_DO_BACKUP_TAGS
 
 
 class ShelveryEngine:
     """Base class for all backup processing, contains logic"""
-
+    
     __metaclass__ = abc.ABCMeta
-
+    
     DEFAULT_KEEP_DAILY = 14
     DEFAULT_KEEP_WEEKLY = 8
     DEFAULT_KEEP_MONTHLY = 12
     DEFAULT_KEEP_YEARLY = 10
-
+    
     BACKUP_RESOURCE_TAG = 'create_backup'
-
+    
     def __init__(self):
         # system logger
         FORMAT = "%(asctime)s %(process)s %(thread)s: %(message)s"
@@ -40,23 +48,110 @@ class ShelveryEngine:
         self.lambda_wait_iteration = 0
         self.lambda_payload = None
         self.lambda_context = None
-
+        self.account_id = AwsHelper.local_account_id()
+        self.region = AwsHelper.local_region()
+        self.snspublisher = ShelveryNotification(RuntimeConfig.get_sns_topic(self))
+    
     def set_lambda_environment(self, payload, context):
         self.lambda_payload = payload
         self.lambda_context = context
         self.aws_request_id = context.aws_request_id
         if ('arguments' in payload) and (LAMBDA_WAIT_ITERATION in payload['arguments']):
             self.lambda_wait_iteration = payload['arguments'][LAMBDA_WAIT_ITERATION]
-
+    
+    @classmethod
+    def get_local_bucket_name(cls, region=None):
+        account_id = AwsHelper.local_account_id()
+        if region is None:
+            region = AwsHelper.local_region()
+        bucket_name = f"shelvery.data.{account_id}-{region}.base2tools"
+        return bucket_name
+    
+    @classmethod
+    def get_remote_bucket_name(cls, account_id, remote_region=None):
+        if remote_region is None:
+            remote_region = AwsHelper.local_region()
+        bucket_name = f"shelvery.data.{account_id}-{remote_region}.base2tools"
+        return bucket_name
+    
+    def _get_data_bucket(self, region=None):
+        bucket_name = self.get_local_bucket_name(region)
+        if region is None:
+            loc_constraint = boto3.session.Session().region_name
+        else:
+            loc_constraint = region
+        
+        s3 = boto3.resource('s3')
+        try:
+            boto3.client('s3').head_bucket(Bucket=bucket_name)
+            bucket = s3.Bucket(bucket_name)
+        
+        except ClientError as e:
+            if e.response['Error']['Code'] == '404':
+                client_region = loc_constraint
+                s3client = boto3.client('s3', region_name=client_region)
+                if loc_constraint == "us-east-1":
+                    bucket = s3client.create_bucket(Bucket=bucket_name)
+                else:
+                    if loc_constraint == "eu-west-1":
+                        loc_constraint = "EU"
+                    
+                    bucket = s3client.create_bucket(Bucket=bucket_name, CreateBucketConfiguration={
+                        'LocationConstraint': loc_constraint
+                    })
+                
+                # store the bucket policy, so the bucket can be accessed from other accounts
+                # that backups are shared with
+                s3client.put_bucket_policy(Bucket=bucket_name,
+                                           Policy=AwsHelper.get_shelvery_bucket_policy(
+                                               self.account_id,
+                                               RuntimeConfig.get_share_with_accounts(self),
+                                               bucket_name)
+                                           )
+                return s3.Bucket(bucket_name)
+            else:
+                raise e
+        return bucket
+    
+    def _archive_backup_metadata(self, backup, bucket):
+        s3key = f"{S3_DATA_PREFIX}/{self.get_engine_type()}/{backup.name}.yaml"
+        s3archive_key = f"{S3_DATA_PREFIX}/{self.get_engine_type()}/removed/{backup.name}.yaml"
+        bucket.put_object(
+            Key=s3archive_key,
+            Body=yaml.dump(backup, default_flow_style=False)
+        )
+        bucket.Object(s3key).delete()
+        
+        self.logger.info(f"Moved meta for backup {backup.name} of type {self.get_engine_type()} to" +
+                         f" s3://{bucket.name}/{s3archive_key}")
+    
+    def _write_backup_data(self, backup, bucket, shared_account_id=None):
+        s3key = f"{S3_DATA_PREFIX}/{self.get_engine_type()}/{backup.name}.yaml"
+        if shared_account_id is not None:
+            s3key = f"{S3_DATA_PREFIX}/shared/{shared_account_id}/{self.get_engine_type()}/{backup.name}.yaml"
+        bucket.put_object(
+            Body=yaml.dump(backup, default_flow_style=False),
+            Key=s3key
+        )
+        self.logger.info(f"Wrote meta for backup {backup.name} of type {self.get_engine_type()} to" +
+                         f" s3://{bucket.name}/{s3key}")
+    
+    def _get_shelvery_shared_backups(self):
+        account_id = RuntimeConfig.get_aws_account_id()
+        for account_id in RuntimeConfig.get_source_backup_accounts(self):
+            bucket = self._get_data_bucket(account_id)
+            path = f"{S3_DATA_PREFIX}/{self.get_engine_type()}/shared/{account_id}"
+    
+    ### Top level methods, invoked externally ####
     def create_backups(self) -> List[BackupResource]:
         """Create backups from all collected entities marked for backup by using specific tag"""
-
+        
         # collect resources to be backed up
         resource_type = self.get_resource_type()
         self.logger.info(f"Collecting entities of type {resource_type} tagged with "
                          f"{RuntimeConfig.get_tag_prefix()}:{self.BACKUP_RESOURCE_TAG}")
         resources = self.get_entities_to_backup(f"{RuntimeConfig.get_tag_prefix()}:{self.BACKUP_RESOURCE_TAG}")
-
+        
         # allows user to select single entity to be backed up
         if RuntimeConfig.get_shelvery_select_entity(self) is not None:
             entity_id = RuntimeConfig.get_shelvery_select_entity(self)
@@ -66,9 +161,9 @@ class ShelveryEngine:
                     lambda x: x.resource_id == entity_id,
                     resources)
             )
-
+        
         self.logger.info(f"{len(resources)} resources of type {resource_type} collected for backup")
-
+        
         # create and collect backups
         backup_resources = []
         for r in resources:
@@ -76,6 +171,8 @@ class ShelveryEngine:
                 tag_prefix=RuntimeConfig.get_tag_prefix(),
                 entity_resource=r
             )
+            dr_regions = RuntimeConfig.get_dr_regions(backup_resource.entity_resource.tags, self)
+            backup_resource.tags[f"{RuntimeConfig.get_tag_prefix()}:dr_regions"] = ','.join(dr_regions)
             self.logger.info(f"Processing {resource_type} with id {r.resource_id}")
             self.logger.info(f"Creating backup {backup_resource.name}")
             try:
@@ -84,23 +181,39 @@ class ShelveryEngine:
                 self.logger.info(f"Created backup of type {resource_type} for entity {backup_resource.entity_id} "
                                  f"with id {backup_resource.backup_id}")
                 backup_resources.append(backup_resource)
+                self.store_backup_data(backup_resource)
+                self.snspublisher.notify({
+                    'Operation': 'CreateBackup',
+                    'Status': 'OK',
+                    'BackupType': self.get_engine_type(),
+                    'BackupName': backup_resource.name,
+                    'EntityId': backup_resource.entity_id
+                })
             except Exception as e:
+                self.snspublisher.notify({
+                    'Operation': 'CreateBackup',
+                    'Status': 'ERROR',
+                    'ExceptionInfo': e.__dict__,
+                    'BackupType': self.get_engine_type(),
+                    'BackupName': backup_resource.name,
+                    'EntityId': backup_resource.entity_id
+                })
                 self.logger.exception(f"Failed to create backup {backup_resource.name}:{e}")
-
+        
         # create backups and disaster recovery region
         for br in backup_resources:
             self.copy_backup(br, RuntimeConfig.get_dr_regions(br.entity_resource.tags, self))
-
+        
         for aws_account_id in RuntimeConfig.get_share_with_accounts(self):
             for br in backup_resources:
                 self.share_backup(br, aws_account_id)
-
+        
         return backup_resources
-
+    
     def clean_backups(self):
         # collect backups
         existing_backups = self.get_existing_backups(RuntimeConfig.get_tag_prefix())
-
+        
         # allows user to select single entity backups to be cleaned
         if RuntimeConfig.get_shelvery_select_entity(self) is not None:
             entity_id = RuntimeConfig.get_shelvery_select_entity(self)
@@ -110,14 +223,14 @@ class ShelveryEngine:
                     lambda x: x.entity_id == entity_id,
                     existing_backups)
             )
-
+        
         self.logger.info(f"Collected {len(existing_backups)} backups to be checked for expiry date")
         self.logger.info(f"""Using following retention settings from runtime environment (resource overrides enabled):
                             Keeping last {RuntimeConfig.get_keep_daily(None, self)} daily backups
                             Keeping last {RuntimeConfig.get_keep_weekly(None, self)} weekly backups
                             Keeping last {RuntimeConfig.get_keep_monthly(None, self)} monthly backups
                             Keeping last {RuntimeConfig.get_keep_yearly(None, self)} yearly backups""")
-
+        
         # check backups for expire date, delete if necessary
         for backup in existing_backups:
             self.logger.info(f"Checking backup {backup.backup_id}")
@@ -126,23 +239,138 @@ class ShelveryEngine:
                     self.logger.info(
                         f"{backup.retention_type} backup {backup.name} has expired on {backup.expire_date}, cleaning up")
                     self.delete_backup(backup)
+                    backup.date_deleted = datetime.utcnow()
+                    self._archive_backup_metadata(backup, self._get_data_bucket())
+                    self.snspublisher.notify({
+                        'Operation': 'DeleteBackup',
+                        'Status': 'OK',
+                        'BackupType': self.get_engine_type(),
+                        'BackupName': backup.name,
+                    })
                 else:
                     self.logger.info(f"{backup.retention_type} backup {backup.name} is valid "
                                      f"until {backup.expire_date}, keeping this backup")
-            except Exception as ex:
-                # TODO notify via SNS
-                self.logger.exception(f"Error checking backup {backup.backup_id} for cleanup: {ex}")
-
+            except Exception as e:
+                self.snspublisher.notify({
+                    'Operation': 'DeleteBackup',
+                    'Status': 'ERROR',
+                    'ExceptionInfo': e.__dict__,
+                    'BackupType': self.get_engine_type(),
+                    'BackupName': backup.name,
+                })
+                self.logger.exception(f"Error checking backup {backup.backup_id} for cleanup: {e}")
+    
+    def pull_shared_backups(self):
+        
+        account_id = self.account_id
+        s3_client = boto3.client('s3')
+        for src_account_id in RuntimeConfig.get_source_backup_accounts(self):
+            try:
+                bucket_name = self.get_remote_bucket_name(src_account_id)
+                path = f"backups/shared/{account_id}/{self.get_engine_type()}/"
+                path_processed = f"backups/shared/{account_id}/{self.get_engine_type()}-processed"
+                path_failed = f"backups/shared/{account_id}/{self.get_engine_type()}-failed"
+                bucket_loc = s3_client.get_bucket_location(Bucket=bucket_name)
+                bucket_region = bucket_loc['LocationConstraint']
+                if bucket_region == 'EU':
+                    bucket_region = 'eu-west-1'
+                elif bucket_region is None:
+                    bucket_region = 'us-east-1'
+                regional_client = boto3.client('s3', region_name=bucket_region)
+                
+                shared_backups = regional_client.list_objects_v2(Bucket=bucket_name, Prefix=path)
+                if 'Contents' in shared_backups:
+                    all_backups = shared_backups['Contents']
+                else:
+                    self.logger.info(f"No shared backups of type {self.get_engine_type()} found to pull")
+                    all_backups = {}
+                while 'NextContinuationToken' in shared_backups:
+                    shared_backups = regional_client.list_objects_v2(
+                        Bucket=bucket_name, Delimiter='/',
+                        Prefix=path, ContinuationToken=shared_backups['NextContinuationToken']
+                    )
+                    all_backups.extend(shared_backups['Contents'])
+                
+                for backup_object in all_backups:
+                    try:
+                        serialised_shared_backup = regional_client.get_object(
+                            Bucket=bucket_name,
+                            Key=backup_object['Key'])['Body'].read()
+                        shared_backup = yaml.load(serialised_shared_backup)
+                        new_backup_id = self.copy_shared_backup(src_account_id, shared_backup)
+                        new_backup = shared_backup.cross_account_copy(new_backup_id)
+                        self.tag_backup_resource(new_backup)
+                        self.store_backup_data(new_backup)
+                        regional_client.delete_object(Bucket=bucket_name, Key=backup_object['Key'])
+                        self.logger.info(f"Removed s3://{bucket_name}/{backup_object['Key']}")
+                        regional_client.put_object(
+                            Bucket=bucket_name,
+                            Key=f"{path_processed}/{shared_backup.name}.yaml",
+                            Body=yaml.dump(shared_backup, default_flow_style=False)
+                        )
+                        self.logger.info(
+                            f"Moved shared backup info to s3://{bucket_name}/{path_processed}/{shared_backup.name}.yaml")
+                        self.snspublisher.notify({
+                            'Operation': 'PullSharedBackup',
+                            'Status': 'OK',
+                            'BackupType': self.get_engine_type(),
+                            'SourceAccount': src_account_id,
+                            'Backup': shared_backup.name
+                        })
+                    except Exception as e:
+                        backup_name = backup_object['Key'].split('/')[-1].replace('.yaml', '')
+                        self.logger.exception(f"Failed to copy shared backup s3://{bucket_name}/{backup_object['Key']}")
+                        self.snspublisher.notify({
+                            'Operation': 'PullSharedBackup',
+                            'Status': 'ERROR',
+                            'ExceptionInfo': e.__dict__,
+                            'BackupType': self.get_engine_type(),
+                            'SourceAccount': src_account_id,
+                            'BackupS3Location': backup_object['Key'],
+                            'NewS3Location': f"{path_failed}/{backup_name}.yaml",
+                            'Bucket': bucket_name
+                        })
+                        regional_client.put_object(
+                            Bucket=bucket_name,
+                            Key=f"{path_failed}/{backup_name}.yaml",
+                            Body=yaml.dump(shared_backup, default_flow_style=False)
+                        )
+                        self.logger.info(
+                            f"Failed share backup operation | backup info moved to s3://{bucket_name}/{path_failed}/{shared_backup.name}.yaml ")
+            
+            except Exception as e:
+                self.snspublisher.notify({
+                    'Operation': 'PullSharedBackupsFromAccount',
+                    'Status': 'ERROR',
+                    'ExceptionInfo': e.__dict__,
+                    'BackupType': self.get_engine_type(),
+                    'SourceAccount': src_account_id,
+                })
+                self.logger.exception("Failed to pull shared backups")
+    
+    def create_data_buckets(self):
+        regions = [self.region]
+        regions.extend(RuntimeConfig.get_dr_regions(None, self))
+        for region in regions:
+            bucket = self._get_data_bucket(region)
+            boto3.client('s3', region_name=region).put_bucket_policy(Bucket=bucket.name,
+                                                 Policy=AwsHelper.get_shelvery_bucket_policy(
+                                                     self.account_id,
+                                                     RuntimeConfig.get_share_with_accounts(self),
+                                                     bucket.name)
+                                                 )
+    
+    ### Helper methods, invoked internally, could be refactored
     def do_wait_backup_available(self, backup_region: str, backup_id: str, timeout_fn=None):
         """Wait for backup to become available. Additionally pass on timeout function
             to be executed if code is running in lambda environment, and remaining execution
             time is lower than threshold of 20 seconds"""
-
+        
         total_wait_time = 0
         retry = 15
         timeout = RuntimeConfig.get_wait_backup_timeout(self)
         self.logger.info(f"Waiting for backup {backup_id} to become available, timing out after {timeout} seconds...")
-
+        
         available = self.is_backup_available(backup_region, backup_id)
         while not available:
             if total_wait_time >= timeout or total_wait_time + retry > timeout:
@@ -152,46 +380,43 @@ class ShelveryEngine:
             time.sleep(retry)
             total_wait_time = total_wait_time + retry
             available = self.is_backup_available(backup_region, backup_id)
-
+    
     def wait_backup_available(self, backup_region: str, backup_id: str, lambda_method: str, lambda_args: Dict) -> bool:
         """Wait for backup to become available. If running in lambda environment, pass lambda method and
             arguments to be executed if lambda functions times out, and return false. Always return true
             in non-lambda mode"""
         has_timed_out = {'value': False}
         engine = self
-
+        
         def call_recursively():
             # check if exceeded allowed number of wait iterations in lambda
             if self.lambda_wait_iteration > RuntimeConfig.get_max_lambda_wait_iterations():
                 raise Exception(f"Reached maximum of {RuntimeConfig.get_max_lambda_wait_iterations()} lambda wait"
                                 f"operations")
-
+            
             lambda_args['lambda_wait_iteration'] = self.lambda_wait_iteration + 1
-            ShelveryInvoker().invoke_shelvery_operation(
-                engine,
-                method_name=lambda_method,
-                method_arguments=lambda_args)
+            if lambda_method is not None and lambda_args is not None:
+                ShelveryInvoker().invoke_shelvery_operation(
+                    engine,
+                    method_name=lambda_method,
+                    method_arguments=lambda_args)
             has_timed_out['value'] = True
-
+        
         def panic():
             self.logger.error(f"Failed to wait for backup to become available, exiting...")
             sys.exit(-5)
-
+        
         # if running in lambda environment, call function recursively on timeout
         # otherwise in cli mode, just exit
         timeout_fn = call_recursively if RuntimeConfig.is_lambda_runtime(self) else panic
         self.do_wait_backup_available(backup_region=backup_region, backup_id=backup_id, timeout_fn=timeout_fn)
         return not (has_timed_out['value'] and RuntimeConfig.is_lambda_runtime(self))
-
+    
     def copy_backup(self, backup_resource: BackupResource, target_regions: List[str]):
         """Copy backup to set of regions - this is orchestration method, rather than
             logic implementation"""
         method = 'do_copy_backup'
-
-        # tag source backup with dr regions
-        backup_resource.tags[f"{RuntimeConfig.get_tag_prefix()}:dr_regions"] = ','.join(target_regions)
-        self.tag_backup_resource(backup_resource)
-
+        
         # call lambda recursively for each backup / region pair
         for region in target_regions:
             arguments = {
@@ -200,13 +425,13 @@ class ShelveryEngine:
                 'Region': region
             }
             ShelveryInvoker().invoke_shelvery_operation(self, method, arguments)
-
+    
     def share_backup(self, backup_resource: BackupResource, aws_account_id: str):
         """
         Share backup with other AWS account - this is orchestration method, rather than
         logic implementation, invokes actual implementation or lambda
         """
-
+        
         method = 'do_share_backup'
         arguments = {
             'Region': backup_resource.region,
@@ -214,14 +439,14 @@ class ShelveryEngine:
             'AwsAccountId': aws_account_id
         }
         ShelveryInvoker().invoke_shelvery_operation(self, method, arguments)
-
+    
     def do_copy_backup(self, map_args={}, **kwargs):
         """
         Copy backup to another region, actual implementation
         """
-
+        
         kwargs.update(map_args)
-
+        
         # if backup is not available, exit and rely on recursive lambda call copy backup
         # in non lambda mode this should never happen
         if not self.wait_backup_available(backup_region=kwargs['OriginRegion'],
@@ -229,47 +454,87 @@ class ShelveryEngine:
                                           lambda_method='do_copy_backup',
                                           lambda_args=kwargs):
             return
-
+        
         self.logger.info(f"Do copy backup {kwargs['BackupId']} ({kwargs['OriginRegion']}) to region {kwargs['Region']}")
-
+        
         # copy backup
-        src_region = kwargs['OriginRegion']
-        dst_region = kwargs['Region']
-        regional_backup_id = self.copy_backup_to_region(kwargs['BackupId'], dst_region)
-
-        # create tags on backup copy
-        original_backup_id = kwargs['BackupId']
-        original_backup = self.get_backup_resource(src_region, original_backup_id)
-        resource_copy = BackupResource(None, None, True)
-        resource_copy.backup_id = regional_backup_id
-        resource_copy.region = kwargs['Region']
-        resource_copy.tags = original_backup.tags.copy()
-
-        # add metadata to dr copy and original
-        dr_copies_tag_key = f"{RuntimeConfig.get_tag_prefix()}:dr_copies"
-        resource_copy.tags[f"{RuntimeConfig.get_tag_prefix()}:region"] = dst_region
-        resource_copy.tags[f"{RuntimeConfig.get_tag_prefix()}:dr_copy"] = 'true'
-        resource_copy.tags[f"{RuntimeConfig.get_tag_prefix()}:dr_source_backup"] = f"{src_region}:{original_backup_id}"
-
-        if dr_copies_tag_key not in original_backup.tags:
-            original_backup.tags[dr_copies_tag_key] = ''
-        original_backup.tags[dr_copies_tag_key] = original_backup.tags[
-                                                      dr_copies_tag_key] + f"{dst_region}:{regional_backup_id} "
-
-        self.tag_backup_resource(resource_copy)
-        self.tag_backup_resource(original_backup)
-
+        try:
+            src_region = kwargs['OriginRegion']
+            dst_region = kwargs['Region']
+            regional_backup_id = self.copy_backup_to_region(kwargs['BackupId'], dst_region)
+            
+            # create tags on backup copy
+            original_backup_id = kwargs['BackupId']
+            original_backup = self.get_backup_resource(src_region, original_backup_id)
+            resource_copy = BackupResource(None, None, True)
+            resource_copy.backup_id = regional_backup_id
+            resource_copy.region = kwargs['Region']
+            resource_copy.tags = original_backup.tags.copy()
+            
+            # add metadata to dr copy and original
+            dr_copies_tag_key = f"{RuntimeConfig.get_tag_prefix()}:dr_copies"
+            resource_copy.tags[f"{RuntimeConfig.get_tag_prefix()}:region"] = dst_region
+            resource_copy.tags[f"{RuntimeConfig.get_tag_prefix()}:dr_copy"] = 'true'
+            resource_copy.tags[
+                f"{RuntimeConfig.get_tag_prefix()}:dr_source_backup"] = f"{src_region}:{original_backup_id}"
+            
+            if dr_copies_tag_key not in original_backup.tags:
+                original_backup.tags[dr_copies_tag_key] = ''
+            original_backup.tags[dr_copies_tag_key] = original_backup.tags[
+                                                          dr_copies_tag_key] + f"{dst_region}:{regional_backup_id} "
+            
+            self.tag_backup_resource(resource_copy)
+            self.tag_backup_resource(original_backup)
+            self.snspublisher.notify({
+                'Operation': 'CopyBackupToRegion',
+                'Status': 'OK',
+                'DestinationRegion': kwargs['Region'],
+                'BackupType': self.get_engine_type(),
+                'BackupId': kwargs['BackupId'],
+            })
+            self.store_backup_data(resource_copy)
+        except Exception as e:
+            self.snspublisher.notify({
+                'Operation': 'CopyBackupToRegion',
+                'Status': 'ERROR',
+                'ExceptionInfo': e.__dict__,
+                'DestinationRegion': kwargs['Region'],
+                'BackupType': self.get_engine_type(),
+                'BackupId': kwargs['BackupId'],
+            })
+            self.logger.exception(f"Error copying backup {kwargs['BackupId']} to {dst_region}")
+        
         # shared backup copy with same accounts
         for shared_account_id in RuntimeConfig.get_share_with_accounts(self):
             backup_resource = BackupResource(None, None, True)
             backup_resource.backup_id = regional_backup_id
             backup_resource.region = kwargs['Region']
-            self.share_backup(backup_resource, shared_account_id)
-
+            try:
+                self.share_backup(backup_resource, shared_account_id)
+                self.snspublisher.notify({
+                    'Operation': 'ShareRegionalBackupCopy',
+                    'Status': 'OK',
+                    'DestinationAccount': shared_account_id,
+                    'DestinationRegion': kwargs['Region'],
+                    'BackupType': self.get_engine_type(),
+                    'BackupId': kwargs['BackupId'],
+                })
+            except Exception as e:
+                self.snspublisher.notify({
+                    'Operation': 'ShareRegionalBackupCopy',
+                    'Status': 'ERROR',
+                    'DestinationAccount': shared_account_id,
+                    'DestinationRegion': kwargs['Region'],
+                    'ExceptionInfo': e.__dict__,
+                    'BackupType': self.get_engine_type(),
+                    'BackupId': kwargs['BackupId'],
+                })
+                self.logger.exception(f"Error sharing copied backup {kwargs['BackupId']} to {dst_region}")
+    
     def do_share_backup(self, map_args={}, **kwargs):
         """Share backup with other AWS account, actual implementation"""
         kwargs.update(map_args)
-
+        
         # if backup is not available, exit and rely on recursive lambda call do share backup
         # in non lambda mode this should never happen
         if not self.wait_backup_available(backup_region=kwargs['Region'],
@@ -277,77 +542,157 @@ class ShelveryEngine:
                                           lambda_method='do_share_backup',
                                           lambda_args=kwargs):
             return
-
-        self.logger.info(f"Do share backup {kwargs['BackupId']} ({kwargs['Region']}) with {kwargs['AwsAccountId']}")
-        self.share_backup_with_account(kwargs['Region'], kwargs['BackupId'], kwargs['AwsAccountId'])
-
+        
+        backup_region = kwargs['Region']
+        backup_id = kwargs['BackupId']
+        destination_account_id = kwargs['AwsAccountId']
+        self.logger.info(f"Do share backup {backup_id} ({backup_region}) with {destination_account_id}")
+        try:
+            self.share_backup_with_account(backup_region, backup_id, destination_account_id)
+            backup_resource = self.get_backup_resource(backup_region, backup_id)
+            self._write_backup_data(
+                backup_resource,
+                self._get_data_bucket(backup_region),
+                destination_account_id
+            )
+            self.snspublisher.notify({
+                'Operation': 'ShareBackup',
+                'Status': 'OK',
+                'BackupType': self.get_engine_type(),
+                'BackupName': backup_resource.name,
+                'DestinationAccount': kwargs['AwsAccountId']
+            })
+        except Exception as e:
+            self.snspublisher.notify({
+                'Operation': 'ShareBackup',
+                'Status': 'ERROR',
+                'ExceptionInfo': e.__dict__,
+                'BackupType': self.get_engine_type(),
+                'BackupId': backup_id,
+                'DestinationAccount': kwargs['AwsAccountId']
+            })
+            self.logger.exception(
+                f"Failed to share backup {backup_id} ({backup_region}) with account {destination_account_id}")
+    
+    def store_backup_data(self, backup_resource: BackupResource):
+        """
+        Top level method to save backup data to s3 bucket.
+        Invokes thread / lambda to wait until backup becomes available and only then
+        the metadata is written to the bucket
+        :param backup_resource:
+        :return:
+        """
+        method = 'do_store_backup_data'
+        arguments = {
+            'BackupId': backup_resource.backup_id,
+            'BackupRegion': backup_resource.region
+        }
+        
+        ShelveryInvoker().invoke_shelvery_operation(self, method, arguments)
+    
+    def do_store_backup_data(self, map_args={}, **kwargs):
+        """
+        Actual logic for writing backup resource data to s3. Waits for backup
+        availability
+        :param map_args:
+        :param kwargs:
+        :return:
+        """
+        kwargs.update(map_args)
+        backup_id = kwargs['BackupId']
+        backup_region = kwargs['BackupRegion']
+        
+        # if backup is not available, exit and rely on recursive lambda call write metadata
+        # in non lambda mode this should never happen
+        if not self.wait_backup_available(backup_region=backup_region,
+                                          backup_id=backup_id,
+                                          lambda_method='do_write_backup_metadata',
+                                          lambda_args=kwargs):
+            return
+        
+        backup_resource = self.get_backup_resource(backup_region, backup_id)
+        if backup_resource.account_id is None:
+            backup_resource.account_id = self.account_id
+        bucket = self._get_data_bucket(backup_resource.region)
+        self._write_backup_data(backup_resource, bucket)
+    
     ####
     # Abstract methods, for engine implementations to implement
     ####
-
+    
+    @abstractmethod
+    def copy_shared_backup(self, source_account: str, source_backup: BackupResource) -> str:
+        """
+        Copy Shelvery backup that has been shared from another account to account where
+        shelvery is currently running
+        :param source_account:
+        :param source_backup:
+        :return:
+        """
+    
     @abstractmethod
     def get_engine_type(self) -> str:
         """
         Return engine type, valid string to be passed to ShelveryFactory.get_shelvery_instance method
         """
-
+    
     @abstractclassmethod
     def get_resource_type(self) -> str:
         """
         Returns entity type that's about to be backed up
         """
-
+    
     @abstractmethod
     def delete_backup(self, backup_resource: BackupResource):
         """
         Remove given backup from system
         """
-
+    
     @abstractmethod
     def get_existing_backups(self, backup_tag_prefix: str) -> List[BackupResource]:
         """
         Collect existing backups on system of given type, marked with given tag
         """
-
+    
     @abstractmethod
     def get_entities_to_backup(self, tag_name: str) -> List[EntityResource]:
         """
         Returns list of objects with 'date_created', 'id' and 'tags' properties
         """
         return []
-
+    
     @abstractmethod
     def backup_resource(self, backup_resource: BackupResource):
         """
         Returns list of objects with 'date_created', 'id' and 'tags' properties
         """
         return
-
+    
     @abstractmethod
     def tag_backup_resource(self, backup_resource: BackupResource):
         """
         Create backup resource tags
         """
-
+    
     @abstractmethod
     def copy_backup_to_region(self, backup_id: str, region: str) -> str:
         """
         Copy backup to another region
         """
-
+    
     @abstractmethod
     def is_backup_available(self, backup_region: str, backup_id: str) -> bool:
         """
         Determine whether backup has completed and is available to be copied
         to other regions and shared with other ebs accounts
         """
-
+    
     @abstractmethod
     def share_backup_with_account(self, backup_region: str, backup_id: str, aws_account_id: str):
         """
         Share backup with another AWS Account
         """
-
+    
     @abstractmethod
     def get_backup_resource(self, backup_region: str, backup_id: str) -> BackupResource:
         """

--- a/shelvery/notifications.py
+++ b/shelvery/notifications.py
@@ -1,0 +1,30 @@
+import boto3
+import json
+import logging
+
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+
+class ShelveryNotification:
+    
+    def __init__(self, topic_arn):
+        self.topic_arn = topic_arn
+        logger.info("Initialized notification service")
+        self.sns = boto3.client('sns')
+    
+    def notify(self, message):
+        if isinstance(message, dict):
+            message['Timestamp'] = datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC")
+            message = json.dumps(message)
+        
+        if self.topic_arn is not None and self.topic_arn.startswith('arn:aws:sns'):
+            try:
+                self.sns.publish(
+                    TopicArn=self.topic_arn,
+                    Message=message
+                )
+            except:
+                logger.exception('Failed publishing to SNS Topic')
+                logger.error(f"Message:{message}")

--- a/shelvery/rds_backup.py
+++ b/shelvery/rds_backup.py
@@ -14,21 +14,21 @@ class ShelveryRDSBackup(ShelveryEngine):
         rds_client = boto3.client('rds', region_name=backup_region)
         snapshots = rds_client.describe_db_snapshots(DBSnapshotIdentifier=backup_id)
         return snapshots['DBSnapshots'][0]['Status'] == 'available'
-
+    
     def get_resource_type(self) -> str:
         return 'RDS Instance'
-
+    
     def backup_resource(self, backup_resource: BackupResource) -> BackupResource:
         if RuntimeConfig.get_rds_mode(backup_resource.entity_resource.tags, self) == RuntimeConfig.RDS_CREATE_SNAPSHOT:
             return self.backup_from_instance(backup_resource)
         if RuntimeConfig.get_rds_mode(backup_resource.entity_resource.tags,
                                       self) == RuntimeConfig.RDS_COPY_AUTOMATED_SNAPSHOT:
             return self.backup_from_latest_automated(backup_resource)
-
+        
         raise Exception(f"Only {RuntimeConfig.RDS_COPY_AUTOMATED_SNAPSHOT} and "
                         f"{RuntimeConfig.RDS_CREATE_SNAPSHOT} rds backup "
                         f"modes supported - set rds backup mode using rds_backup_mode configuration option ")
-
+    
     def backup_from_latest_automated(self, backup_resource: BackupResource):
         rds_client = boto3.client('rds')
         auto_snapshots = rds_client.describe_db_snapshots(
@@ -38,12 +38,12 @@ class ShelveryRDSBackup(ShelveryEngine):
             MaxRecords=20
         )
         auto_snapshots = sorted(auto_snapshots['DBSnapshots'], key=lambda k: k['SnapshotCreateTime'], reverse=True)
-
+        
         if len(auto_snapshots) == 0:
             self.logger.error(f"There is no latest automated backup for cluster {backup_resource.entity_id},"
                               f" fallback to RDS_CREATE_SNAPSHOT mode. Creating snapshot directly on cluster...")
             return self.backup_from_instance(backup_resource)
-
+        
         automated_snapshot_id = auto_snapshots[0]['DBSnapshotIdentifier']
         rds_client.copy_db_snapshot(
             SourceDBSnapshotIdentifier=automated_snapshot_id,
@@ -52,7 +52,7 @@ class ShelveryRDSBackup(ShelveryEngine):
         )
         backup_resource.backup_id = backup_resource.name
         return backup_resource
-
+    
     def backup_from_instance(self, backup_resource):
         rds_client = boto3.client('rds')
         rds_client.create_db_snapshot(
@@ -61,13 +61,13 @@ class ShelveryRDSBackup(ShelveryEngine):
         )
         backup_resource.backup_id = backup_resource.name
         return backup_resource
-
+    
     def delete_backup(self, backup_resource: BackupResource):
         rds_client = boto3.client('rds')
         rds_client.delete_db_snapshot(
             DBSnapshotIdentifier=backup_resource.backup_id
         )
-
+    
     def tag_backup_resource(self, backup_resource: BackupResource):
         regional_rds_client = boto3.client('rds', region_name=backup_resource.region)
         snapshots = regional_rds_client.describe_db_snapshots(DBSnapshotIdentifier=backup_resource.backup_id)
@@ -77,18 +77,18 @@ class ShelveryRDSBackup(ShelveryEngine):
             Tags=list(
                 map(lambda k: {'Key': k, 'Value': backup_resource.tags[k].replace(',', ' ')}, backup_resource.tags))
         )
-
+    
     def get_existing_backups(self, backup_tag_prefix: str) -> List[BackupResource]:
         rds_client = boto3.client('rds')
-
+        
         # collect all snapshots
         all_snapshots = self.collect_all_snapshots(rds_client)
-
+        
         # filter ones backed up with shelvery
         all_backups = self.get_shelvery_backups_only(all_snapshots, backup_tag_prefix, rds_client)
-
+        
         return all_backups
-
+    
     def share_backup_with_account(self, backup_region: str, backup_id: str, aws_account_id: str):
         rds_client = boto3.client('rds', region_name=backup_region)
         rds_client.modify_db_snapshot_attribute(
@@ -96,7 +96,7 @@ class ShelveryRDSBackup(ShelveryEngine):
             AttributeName='restore',
             ValuesToAdd=[aws_account_id]
         )
-
+    
     def copy_backup_to_region(self, backup_id: str, region: str) -> str:
         local_region = boto3.session.Session().region_name
         client_local = boto3.client('rds')
@@ -111,7 +111,7 @@ class ShelveryRDSBackup(ShelveryEngine):
             CopyTags=False
         )
         return backup_id
-
+    
     def get_backup_resource(self, backup_region: str, backup_id: str) -> BackupResource:
         rds_client = boto3.client('rds', region_name=backup_region)
         snapshots = rds_client.describe_db_snapshots(DBSnapshotIdentifier=backup_id)
@@ -119,33 +119,33 @@ class ShelveryRDSBackup(ShelveryEngine):
         tags = rds_client.list_tags_for_resource(ResourceName=snapshot['DBSnapshotArn'])['TagList']
         d_tags = dict(map(lambda t: (t['Key'], t['Value']), tags))
         return BackupResource.construct(d_tags['shelvery:tag_name'], backup_id, d_tags)
-
+    
     def get_engine_type(self) -> str:
         return 'rds'
-
+    
     def get_entities_to_backup(self, tag_name: str) -> List[EntityResource]:
         # region and api client
         local_region = boto3.session.Session().region_name
         rds_client = boto3.client('rds')
-
+        
         # list of models returned from api
         db_entities = []
-
+        
         db_instances = self.get_all_instances(rds_client)
-
+        
         # collect tags in check if instance tagged with marker tag
-
+        
         for instance in db_instances:
             tags = rds_client.list_tags_for_resource(ResourceName=instance['DBInstanceArn'])['TagList']
-
+            
             # convert api response to dictionary
             d_tags = dict(map(lambda t: (t['Key'], t['Value']), tags))
-
+            
             if 'DBClusterIdentifier' in instance:
                 self.logger.info(f"Skipping RDS Instance {instance['DBInstanceIdentifier']} skipped as it is part"
                                  f" of cluster {instance['DBClusterIdentifier']}")
                 continue
-
+            
             # check if marker tag is present
             if tag_name in d_tags and d_tags[tag_name] in SHELVERY_DO_BACKUP_TAGS:
                 resource = EntityResource(instance['DBInstanceIdentifier'],
@@ -153,9 +153,9 @@ class ShelveryRDSBackup(ShelveryEngine):
                                           instance['InstanceCreateTime'],
                                           d_tags)
                 db_entities.append(resource)
-
+        
         return db_entities
-
+    
     def get_all_instances(self, rds_client):
         """
         Get all RDS instances within region for given boto3 client
@@ -171,9 +171,9 @@ class ShelveryRDSBackup(ShelveryEngine):
         while 'Marker' in temp_instances:
             temp_instances = rds_client.describe_db_instances(Marker=temp_instances['Marker'])
             db_instances.extend(temp_instances['DBInstances'])
-
+        
         return db_instances
-
+    
     def get_shelvery_backups_only(self, all_snapshots, backup_tag_prefix, rds_client):
         """
         :param all_snapshots: all snapshots within region
@@ -192,11 +192,23 @@ class ShelveryRDSBackup(ShelveryEngine):
                     backup_resource = BackupResource.construct(backup_tag_prefix, snap['DBSnapshotIdentifier'], d_tags)
                     backup_resource.entity_resource = snap['EntityResource']
                     backup_resource.entity_id = snap['EntityResource'].resource_id
-
+                    
                     all_backups.append(backup_resource)
-
+        
         return all_backups
-
+    
+    def copy_shared_backup(self, source_account: str, source_backup: BackupResource):
+        rds_client = boto3.client('rds')
+        # copying of tags happens outside this method
+        source_arn = f"arn:aws:rds:{source_backup.region}:{source_backup.account_id}:snapshot:{source_backup.backup_id}"
+        snap = rds_client.copy_db_snapshot(
+            SourceDBSnapshotIdentifier=source_arn,
+            SourceRegion=source_backup.region,
+            CopyTags=False,
+            TargetDBSnapshotIdentifier=source_backup.backup_id
+        )
+        return snap['DBSnapshot']['DBSnapshotIdentifier']
+    
     def collect_all_snapshots(self, rds_client):
         """
         :param rds_client:
@@ -208,11 +220,11 @@ class ShelveryRDSBackup(ShelveryEngine):
         while 'Marker' in tmp_snapshots:
             tmp_snapshots = rds_client.describe_db_snapshots(Marker=tmp_snapshots['Marker'])
             all_snapshots.extend(tmp_snapshots['DBSnapshots'])
-
+        
         self.populate_snap_entity_resource(all_snapshots)
-
+        
         return all_snapshots
-
+    
     def populate_snap_entity_resource(self, all_snapshots):
         instance_ids = []
         for snap in all_snapshots:
@@ -221,7 +233,7 @@ class ShelveryRDSBackup(ShelveryEngine):
         entities = {}
         rds_client = boto3.client('rds')
         local_region = boto3.session.Session().region_name
-
+        
         for instance_id in instance_ids:
             try:
                 rds_instance = rds_client.describe_db_instances(DBInstanceIdentifier=instance_id)['DBInstances'][0]
@@ -238,7 +250,7 @@ class ShelveryRDSBackup(ShelveryEngine):
                     entities[instance_id].resource_id = instance_id
                 else:
                     raise e
-
+        
         for snap in all_snapshots:
             if snap['DBInstanceIdentifier'] in entities:
                 snap['EntityResource'] = entities[snap['DBInstanceIdentifier']]

--- a/shelvery/rds_backup.py
+++ b/shelvery/rds_backup.py
@@ -206,7 +206,7 @@ class ShelveryRDSBackup(ShelveryEngine):
         tmp_snapshots = rds_client.describe_db_snapshots(SnapshotType='manual')
         all_snapshots.extend(tmp_snapshots['DBSnapshots'])
         while 'Marker' in tmp_snapshots:
-            tmp_snapshots = rds_client.describe_db_snapshots()
+            tmp_snapshots = rds_client.describe_db_snapshots(Marker=tmp_snapshots['Marker'])
             all_snapshots.extend(tmp_snapshots['DBSnapshots'])
 
         self.populate_snap_entity_resource(all_snapshots)

--- a/shelvery/rds_cluster_backup.py
+++ b/shelvery/rds_cluster_backup.py
@@ -114,6 +114,18 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
             CopyTags=False
         )
         return backup_id
+
+    def copy_shared_backup(self, source_account: str, source_backup: BackupResource):
+        rds_client = boto3.client('rds')
+        # copying of tags happens outside this method
+        source_arn = f"arn:aws:rds:{source_backup.region}:{source_backup.account_id}:cluster-snapshot:{source_backup.backup_id}"
+        snap = rds_client.copy_db_cluster_snapshot(
+            SourceDBClusterSnapshotIdentifier=source_arn,
+            SourceRegion=source_backup.region,
+            CopyTags=False,
+            TargetDBClusterSnapshotIdentifier=source_backup.backup_id
+        )
+        return snap['DBClusterSnapshot']['DBClusterSnapshotIdentifier']
     
     def get_backup_resource(self, backup_region: str, backup_id: str) -> BackupResource:
         rds_client = boto3.client('rds', region_name=backup_region)

--- a/shelvery/runtime_config.py
+++ b/shelvery/runtime_config.py
@@ -1,5 +1,6 @@
 import re
 import os
+import boto3
 
 
 class RuntimeConfig:
@@ -31,18 +32,23 @@ class RuntimeConfig:
 
     shelvery_share_aws_account_ids - AWS Account Ids to share backups with. Applies to both original and regional
                                     backups
+                                    
+    shelvery_source_aws_account_ids - AWS Account Ids that are sharing shelvery backups with AWS Account shelvery
+                                    is running in. Used for 'pull backups' feature
 
     shelvery_select_entity - Filter which entities get backed up, regardless of tags
+    
+    shelvery_sns_topic - SNS Topics for shelvery notifications
     """
-
+    
     DEFAULT_KEEP_DAILY = 14
     DEFAULT_KEEP_WEEKLY = 8
     DEFAULT_KEEP_MONTHLY = 12
     DEFAULT_KEEP_YEARLY = 10
-
+    
     RDS_COPY_AUTOMATED_SNAPSHOT = 'RDS_COPY_AUTOMATED_SNAPSHOT'
     RDS_CREATE_SNAPSHOT = 'RDS_CREATE_SNAPSHOT'
-
+    
     DEFAULTS = {
         'shelvery_keep_daily_backups': 14,
         'shelvery_keep_weekly_backups': 8,
@@ -52,9 +58,10 @@ class RuntimeConfig:
         'shelvery_lambda_max_wait_iterations': 5,
         'shelvery_dr_regions': None,
         'shelvery_rds_backup_mode': RDS_COPY_AUTOMATED_SNAPSHOT,
-        'shelvery_select_entity': None
+        'shelvery_select_entity': None,
+        'shelvery_source_aws_account_ids': None
     }
-
+    
     @classmethod
     def get_conf_value(cls, key: str, resource_tags=None, lambda_payload=None):
         # priority 3 are resource tags
@@ -62,52 +69,52 @@ class RuntimeConfig:
             tag_key = f"shelvery:config:{key}"
             if tag_key in resource_tags:
                 return resource_tags[tag_key]
-
+        
         # priority 2 is lambda payload
         if (lambda_payload is not None) and ('config' in lambda_payload) and (key in lambda_payload['config']):
             return lambda_payload['config'][key]
-
+        
         # priority 1 are environment variables
         if key in os.environ:
             return os.environ[key]
-
+        
         # priority 0 are defaults
         if key in cls.DEFAULTS:
             return cls.DEFAULTS[key]
-
+    
     @classmethod
     def is_lambda_runtime(cls, engine) -> bool:
         return engine.aws_request_id != 0 and engine.lambda_payload is not None
-
+    
     @classmethod
     def get_keep_daily(cls, resource_tags=None, engine=None):
         return int(cls.get_conf_value('shelvery_keep_daily_backups', resource_tags, engine.lambda_payload))
-
+    
     @classmethod
     def get_keep_weekly(cls, resource_tags=None, engine=None):
         return int(cls.get_conf_value('shelvery_keep_weekly_backups', resource_tags, engine.lambda_payload))
-
+    
     @classmethod
     def get_keep_monthly(cls, resource_tags=None, engine=None):
         return int(cls.get_conf_value('shelvery_keep_monthly_backups', resource_tags, engine.lambda_payload))
-
+    
     @classmethod
     def get_keep_yearly(cls, resource_tags=None, engine=None):
         return int(cls.get_conf_value('shelvery_keep_yearly_backups', resource_tags, engine.lambda_payload))
-
+    
     @classmethod
     def get_envvalue(cls, key: str, default_value):
         return os.environ[key] if key in os.environ else default_value
-
+    
     @classmethod
     def get_tag_prefix(cls):
         return cls.get_envvalue('shelvery_tag_prefix', 'shelvery')
-
+    
     @classmethod
     def get_dr_regions(cls, resource_tags, engine):
         regions = cls.get_conf_value('shelvery_dr_regions', resource_tags, engine.lambda_payload)
         return [] if regions is None else regions.split(',')
-
+    
     @classmethod
     def is_started_internally(cls, engine) -> bool:
         # 1. running in lambda environment
@@ -116,42 +123,68 @@ class RuntimeConfig:
         return cls.is_lambda_runtime(engine) \
                and 'is_started_internally' in engine.lambda_payload \
                and engine.lambda_payload['is_started_internally']
-
+    
     @classmethod
     def get_wait_backup_timeout(cls, shelvery):
         if cls.is_lambda_runtime(shelvery):
             return (shelvery.lambda_context.get_remaining_time_in_millis() / 1000) - 20
         else:
             return int(cls.get_conf_value('shelvery_wait_snapshot_timeout', None, shelvery.lambda_payload))
-
+    
     @classmethod
     def get_max_lambda_wait_iterations(cls):
         return int(cls.get_envvalue('shelvery_lambda_max_wait_iterations', '5'))
-
+    
     @classmethod
     def get_share_with_accounts(cls, shelvery):
         # collect account from env vars
         accounts = cls.get_conf_value('shelvery_share_aws_account_ids', None, shelvery.lambda_payload)
-
+        
         # by default it is empty list
         accounts = accounts.split(',') if accounts is not None else []
-
+        
         # validate account format
         for acc in accounts:
             if re.match('^[0-9]{12}$', acc) is None:
                 shelvery.logger.warn(f"Account id {acc} is not 12-digit number, skipping for share")
             else:
                 shelvery.logger.info(f"Collected account {acc} to share backups with")
-
+        
         return accounts
-
+    
+    @classmethod
+    def get_source_backup_accounts(cls, shelvery):
+        # collect account from env vars
+        accounts = cls.get_conf_value('shelvery_source_aws_account_ids', None, shelvery.lambda_payload)
+        
+        # by default it is empty list
+        accounts = accounts.split(',') if accounts is not None else []
+        
+        # validate account format
+        for acc in accounts:
+            if re.match('^[0-9]{12}$', acc) is None:
+                shelvery.logger.warn(f"Account id {acc} is not 12-digit number, skipping for share")
+            else:
+                shelvery.logger.info(f"Collected account {acc} to share backups with")
+        
+        return accounts
+    
     @classmethod
     def get_rds_mode(cls, resource_tags, engine):
         return cls.get_conf_value('shelvery_rds_backup_mode', resource_tags, engine.lambda_payload)
-
+    
     @classmethod
     def get_shelvery_select_entity(cls, engine):
         val = cls.get_conf_value('shelvery_select_entity', None, engine.lambda_payload)
         if val == '':
             return None
         return val
+    
+    @classmethod
+    def get_aws_account_id(cls):
+        # TODO cache
+        return boto3.client('sts').get_caller_identity()['Account']
+    
+    @classmethod
+    def get_sns_topic(cls, engine):
+        return cls.get_conf_value('shelvery_sns_topic', None, engine.lambda_payload)

--- a/shelvery_cli/__main__.py
+++ b/shelvery_cli/__main__.py
@@ -22,8 +22,13 @@ def main(args=None):
 
     if args is None:
         args = sys.argv[1:]
+        # for create data buckets, engine does not matter,
+        # probably should extract all S3 things in separate class
+    if len(args) == 1 and args[0] == 'create_data_buckets':
+        args.insert(0, 'ebs')
     if len(args) < 2:
-        print("Usage: shelvery <backup_type> <action>\n\nBackup types: rds ebs rds_cluster ec2ami\nActions: create_backups clean_backups")
+        print("""Usage: shelvery <backup_type> <action>\n\nBackup types: rds ebs rds_cluster ec2ami
+Actions:\n\tcreate_backups\n\tclean_backups\n\tcreate_data_buckets\n\tpull_shared_backups""")
         exit(-2)
 
     setup_logging()

--- a/shelvery_tests/name_transformation_test.py
+++ b/shelvery_tests/name_transformation_test.py
@@ -1,0 +1,132 @@
+import sys
+import traceback
+import unittest
+import yaml
+import boto3
+import os
+import time
+import botocore
+from datetime import datetime
+
+pwd = os.path.dirname(os.path.abspath(__file__))
+
+sys.path.append(f"{pwd}/..")
+sys.path.append(f"{pwd}/../shelvery")
+sys.path.append(f"{pwd}/shelvery")
+sys.path.append(f"{pwd}/lib")
+sys.path.append(f"{pwd}/../lib")
+
+from shelvery.ebs_backup import ShelveryEBSBackup
+from shelvery.engine import ShelveryEngine
+from shelvery.engine import S3_DATA_PREFIX
+from shelvery.runtime_config import RuntimeConfig
+from shelvery.backup_resource import BackupResource
+
+print(f"Python lib path:\n{sys.path}")
+
+NAME_WITH_SPECIAL_CHARACTERS = 'shelvery&#^--_auto_mate_d_tests'
+NAME_TRANSFORMED = 'shelvery-auto-mate-d-tests'
+
+class ShelveryNameTransformationTestCase(unittest.TestCase):
+    """Shelvery EBS Backups Integration shelvery_tests"""
+    
+    def id(self):
+        return str(self.__class__)
+    
+    def setUp(self):
+        self.volume = None
+        self.created_snapshots = []
+        self.regional_snapshots = {
+            'us-west-1': [],
+            'us-west-2': []
+        }
+        
+        print(f"Setting up ebs integraion test")
+        print("Create EBS Volume of 1G")
+        os.environ['AWS_DEFAULT_REGION'] = 'us-east-1'
+        os.environ['SHELVERY_MONO_THREAD'] = '1'
+        ec2client = boto3.client('ec2')
+        sts = boto3.client('sts')
+        self.id = sts.get_caller_identity()
+        print(f"Running as user:\n{self.id}\n")
+        self.volume = ec2client.create_volume(AvailabilityZone='us-east-1a',
+                                              Encrypted=False,
+                                              Size=1,
+                                              VolumeType='gp2',
+                                              TagSpecifications=[{
+                                                  'ResourceType': 'volume',
+                                                  'Tags': [{
+                                                      'Key': f"{RuntimeConfig.get_tag_prefix()}:{ShelveryEngine.BACKUP_RESOURCE_TAG}",
+                                                      'Value': 'true'
+                                                  }, {'Key': 'Name', 'Value': NAME_WITH_SPECIAL_CHARACTERS}]
+                                              }])
+        
+        # wait until volume is available
+        interm_volume = ec2client.describe_volumes(VolumeIds=[self.volume['VolumeId']])['Volumes'][0]
+        while interm_volume['State'] != 'available':
+            time.sleep(5)
+            interm_volume = ec2client.describe_volumes(VolumeIds=[self.volume['VolumeId']])['Volumes'][0]
+        
+        print(f"Created volume: {self.volume}")
+        # TODO wait until volume is 'available'
+        self.share_with_id = int(self.id['Account']) + 1
+        os.environ['shelvery_select_entity'] = self.volume['VolumeId']
+    
+    def tearDown(self):
+        ec2client = boto3.client('ec2')
+        ec2client.delete_volume(VolumeId=self.volume['VolumeId'])
+        print(f"Deleted volume:\n{self.volume['VolumeId']}\n")
+        
+        # snapshot deletion surrounded with try/except in order
+        # for cases when shelvery cleans / does not clean up behind itself
+        for snapid in self.created_snapshots:
+            print(f"Deleting snapshot {snapid}")
+            try:
+                ec2client.delete_snapshot(SnapshotId=snapid)
+            except Exception as e:
+                print(f"Failed to delete {snapid}:{str(e)}")
+        
+        for region in self.regional_snapshots:
+            ec2regional = boto3.client('ec2', region_name=region)
+            for snapid in self.regional_snapshots[region]:
+                try:
+                    ec2regional.delete_snapshot(SnapshotId=snapid)
+                except Exception as e:
+                    print(f"Failed to delete {snapid}:{str(e)}")
+    
+    def test_NameTransformed(self):
+        ebs_backups_engine = ShelveryEBSBackup()
+        try:
+            backups = ebs_backups_engine.create_backups()
+        except Exception as e:
+            print(e)
+            print(f"Failed with {e}")
+            traceback.print_exc(file=sys.stdout)
+            raise e
+        ec2client = boto3.client('ec2')
+        
+        valid = False
+        # validate there is
+        for backup in backups:
+            if backup.entity_id == self.volume['VolumeId']:
+                snapshot_id = backup.backup_id
+                self.created_snapshots.append(snapshot_id)
+                
+                # wait for snapshot to become available
+                snapshots = ec2client.describe_snapshots(SnapshotIds=[snapshot_id])['Snapshots']
+                self.assertTrue(len(snapshots) == 1)
+                self.assertTrue(snapshots[0]['VolumeId'] == self.volume['VolumeId'])
+                d_tags = dict(map(lambda x: (x['Key'], x['Value']), snapshots[0]['Tags']))
+
+                self.assertTrue(d_tags['Name'].startswith(NAME_TRANSFORMED))
+                print(f"required: {backup.date_created.strftime(BackupResource.TIMESTAMP_FORMAT)}-{backup.retention_type}")
+                print(f"actual: {d_tags['Name']}")
+                self.assertTrue(d_tags['Name'].endswith(f"{backup.date_created.strftime(BackupResource.TIMESTAMP_FORMAT)}-{backup.retention_type}"))
+                
+                valid = True
+        
+        self.assertTrue(valid)
+    
+
+if __name__ == '__main__':
+    unittest.main()

--- a/shelvery_tests/s3data_integration_test.py
+++ b/shelvery_tests/s3data_integration_test.py
@@ -1,7 +1,7 @@
 import sys
 import traceback
 import unittest
-
+import yaml
 import boto3
 import os
 import time
@@ -18,18 +18,19 @@ sys.path.append(f"{pwd}/../lib")
 
 from shelvery.ebs_backup import ShelveryEBSBackup
 from shelvery.engine import ShelveryEngine
+from shelvery.engine import S3_DATA_PREFIX
 from shelvery.runtime_config import RuntimeConfig
 from shelvery.backup_resource import BackupResource
 
 print(f"Python lib path:\n{sys.path}")
 
 
-class ShelveryEBSIntegrationTestCase(unittest.TestCase):
+class ShelveryS3DataTestCase(unittest.TestCase):
     """Shelvery EBS Backups Integration shelvery_tests"""
-
+    
     def id(self):
         return str(self.__class__)
-
+    
     def setUp(self):
         self.volume = None
         self.created_snapshots = []
@@ -37,7 +38,7 @@ class ShelveryEBSIntegrationTestCase(unittest.TestCase):
             'us-west-1': [],
             'us-west-2': []
         }
-
+        
         print(f"Setting up ebs integraion test")
         print("Create EBS Volume of 1G")
         os.environ['AWS_DEFAULT_REGION'] = 'us-east-1'
@@ -57,23 +58,23 @@ class ShelveryEBSIntegrationTestCase(unittest.TestCase):
                                                       'Value': 'true'
                                                   }, {'Key': 'Name', 'Value': 'shelvery-automated-shelvery_tests'}]
                                               }])
-
+        
         # wait until volume is available
         interm_volume = ec2client.describe_volumes(VolumeIds=[self.volume['VolumeId']])['Volumes'][0]
         while interm_volume['State'] != 'available':
             time.sleep(5)
             interm_volume = ec2client.describe_volumes(VolumeIds=[self.volume['VolumeId']])['Volumes'][0]
-
+        
         print(f"Created volume: {self.volume}")
         # TODO wait until volume is 'available'
         self.share_with_id = int(self.id['Account']) + 1
         os.environ['shelvery_select_entity'] = self.volume['VolumeId']
-
+    
     def tearDown(self):
         ec2client = boto3.client('ec2')
         ec2client.delete_volume(VolumeId=self.volume['VolumeId'])
         print(f"Deleted volume:\n{self.volume['VolumeId']}\n")
-
+        
         # snapshot deletion surrounded with try/except in order
         # for cases when shelvery cleans / does not clean up behind itself
         for snapid in self.created_snapshots:
@@ -82,7 +83,7 @@ class ShelveryEBSIntegrationTestCase(unittest.TestCase):
                 ec2client.delete_snapshot(SnapshotId=snapid)
             except Exception as e:
                 print(f"Failed to delete {snapid}:{str(e)}")
-
+        
         for region in self.regional_snapshots:
             ec2regional = boto3.client('ec2', region_name=region)
             for snapid in self.regional_snapshots[region]:
@@ -90,8 +91,8 @@ class ShelveryEBSIntegrationTestCase(unittest.TestCase):
                     ec2regional.delete_snapshot(SnapshotId=snapid)
                 except Exception as e:
                     print(f"Failed to delete {snapid}:{str(e)}")
-
-    def test_CreateBackups(self):
+    
+    def test_CreateBackupData(self):
         ebs_backups_engine = ShelveryEBSBackup()
         try:
             backups = ebs_backups_engine.create_backups()
@@ -101,26 +102,48 @@ class ShelveryEBSIntegrationTestCase(unittest.TestCase):
             traceback.print_exc(file=sys.stdout)
             raise e
         ec2client = boto3.client('ec2')
-
+        
         valid = False
         # validate there is
         for backup in backups:
             if backup.entity_id == self.volume['VolumeId']:
                 snapshot_id = backup.backup_id
                 self.created_snapshots.append(snapshot_id)
-                snapshots = ec2client.describe_snapshots(SnapshotIds=[snapshot_id])['Snapshots']
-                self.assertTrue(len(snapshots) == 1)
-                self.assertTrue(snapshots[0]['VolumeId'] == self.volume['VolumeId'])
-                d_tags = dict(map(lambda x: (x['Key'], x['Value']), snapshots[0]['Tags']))
-                marker_tag = f"{RuntimeConfig.get_tag_prefix()}:{BackupResource.BACKUP_MARKER_TAG}"
-                self.assertTrue(marker_tag in d_tags)
-                self.assertTrue(f"{RuntimeConfig.get_tag_prefix()}:entity_id" in d_tags)
-                self.assertTrue(d_tags[f"{RuntimeConfig.get_tag_prefix()}:entity_id"] == self.volume['VolumeId'])
+                
+                # wait for snapshot to become available
+                ebs_backups_engine.wait_backup_available(backup.region, backup.backup_id, None, None)
+                
+                # allow buffer period for engine to write data to s3
+                time.sleep(20)
+                
+                # this is the backup that gets stored in s3
+                engine_backup = ebs_backups_engine.get_backup_resource(backup.region, backup.backup_id)
+                # verify the s3 data
+                account_id = ebs_backups_engine.account_id
+                s3path = f"{S3_DATA_PREFIX}/{ebs_backups_engine.get_engine_type()}/{engine_backup.name}.yaml"
+                s3bucket = ShelveryEngine.get_local_bucket_name()
+                print(f"Usingbucket {s3bucket}")
+                print(f"Using path {s3path}")
+                bucket = boto3.resource('s3').Bucket(s3bucket)
+                object = bucket.Object(s3path)
+                content = object.get()['Body'].read()
+                restored_br = yaml.load(content)
+                self.assertEquals(restored_br.backup_id, engine_backup.backup_id)
+                self.assertEquals(restored_br.name, engine_backup.name)
+                self.assertEquals(restored_br.region, engine_backup.region)
+                print(f"Tags restored: \n{yaml.dump(restored_br.tags)}\n")
+                print(f"Tags backup: \n{yaml.dump(engine_backup.tags)}\n")
+                self.assertEquals(restored_br.tags['Name'], engine_backup.tags['Name'])
+                for tag in ['name','date_created','entity_id','region','retention_type']:
+                    self.assertEquals(
+                        restored_br.tags[f"{RuntimeConfig.get_tag_prefix()}:{tag}"],
+                        engine_backup.tags[f"{RuntimeConfig.get_tag_prefix()}:{tag}"]
+                    )
                 valid = True
-
+        
         self.assertTrue(valid)
-
-    def test_ShareBackups(self):
+    
+    def test_CreateSharingInfo(self):
         ebs_backups_engine = ShelveryEBSBackup()
         try:
             os.environ["shelvery_share_aws_account_ids"] = str(self.share_with_id)
@@ -132,75 +155,31 @@ class ShelveryEBSIntegrationTestCase(unittest.TestCase):
             raise e
         finally:
             del os.environ["shelvery_share_aws_account_ids"]
-
-        ec2 = boto3.resource('ec2')
+        
         valid = False
-        # validate there is
-        for backup in backups:
-            print(f"VolumeId={self.volume['VolumeId']}")
-            print(f"EntityId={backup.entity_id}")
-            if backup.entity_id == self.volume['VolumeId']:
-                print(f"Testing snap {backup.entity_id} if shared with {self.share_with_id}")
-                snapshot_id = backup.backup_id
-                self.created_snapshots.append(snapshot_id)
-                snapshot = ec2.Snapshot(snapshot_id)
-                attr = snapshot.describe_attribute(Attribute='createVolumePermission')
-                print(f"CreateVolumePermissions: {attr}")
-                userlist = attr['CreateVolumePermissions']
-                self.assertTrue(str(self.share_with_id) in list(map(lambda x: x['UserId'], userlist)))
-                valid = True
-
-        self.assertTrue(valid)
-
-    def test_CopyBackups(self):
-        ebs_backups_engine = ShelveryEBSBackup()
-        try:
-            os.environ['shelvery_dr_regions'] = 'us-west-2'
-            backups = ebs_backups_engine.create_backups()
-        except Exception as e:
-            print(e)
-            print(f"Failed with {e}")
-            traceback.print_exc(file=sys.stdout)
-            raise e
-        finally:
-            del os.environ["shelvery_dr_regions"]
-
-        ec2dr_region = boto3.client('ec2', region_name='us-west-2')
-        valid = False
-        # validate there is
         for backup in backups:
             if backup.entity_id == self.volume['VolumeId']:
-                print(
-                    f"Testing snap {backup.entity_id} if copied to region us-west-2")
-                snapshot_id = backup.backup_id
-                self.created_snapshots.append(snapshot_id)
-                drsnapshot = ec2dr_region.describe_snapshots(Filters=[
-                    {'Name': f"tag:{RuntimeConfig.get_tag_prefix()}:entity_id",
-                     'Values': [self.volume['VolumeId']]
-                     }])['Snapshots'][0]
-                drsnapshot_dtags = dict(map(lambda x: (x['Key'], x['Value']), drsnapshot['Tags']))
-
-                tag_key = f"{RuntimeConfig.get_tag_prefix()}:dr_copy"
-                tag_value = 'true'
-                self.assertTrue(tag_key in drsnapshot_dtags)
-                self.assertEquals(drsnapshot_dtags[tag_key], tag_value)
-
-                tag_key = f"{RuntimeConfig.get_tag_prefix()}:dr_source_backup"
-                tag_value = f"us-east-1:{snapshot_id}"
-                self.assertTrue(tag_key in drsnapshot_dtags)
-                self.assertEquals(drsnapshot_dtags[tag_key], tag_value)
-
-                tag_key = f"{RuntimeConfig.get_tag_prefix()}:region"
-                tag_value = 'us-west-2'
-                self.assertTrue(tag_key in drsnapshot_dtags)
-                self.assertEquals(drsnapshot_dtags[tag_key], tag_value)
-
-                self.regional_snapshots['us-west-2'].append(drsnapshot['SnapshotId'])
+                account_id = ebs_backups_engine.account_id
+                s3path = f"{S3_DATA_PREFIX}/shared/{self.share_with_id}/{ebs_backups_engine.get_engine_type()}/{backup.name}.yaml"
+                s3bucket = ShelveryEngine.get_local_bucket_name()
+                bucket = boto3.resource('s3').Bucket(s3bucket)
+                object = bucket.Object(s3path)
+                content = object.get()['Body'].read()
+                restored_br = yaml.load(content)
+                engine_backup = ebs_backups_engine.get_backup_resource(backup.region, backup.backup_id)
+                self.assertEquals(restored_br.backup_id, engine_backup.backup_id)
+                self.assertEquals(restored_br.name, engine_backup.name)
+                self.assertEquals(restored_br.region, engine_backup.region)
+                for tag in ['name','date_created','entity_id','region','retention_type']:
+                    self.assertEquals(
+                        restored_br.tags[f"{RuntimeConfig.get_tag_prefix()}:{tag}"],
+                        engine_backup.tags[f"{RuntimeConfig.get_tag_prefix()}:{tag}"]
+                    )
                 valid = True
-
+        
         self.assertTrue(valid)
-
-    def test_CleanBackups(self):
+    
+    def test_CleanBackupData(self):
         ebs_backups_engine = ShelveryEBSBackup()
         try:
             backups = ebs_backups_engine.create_backups()
@@ -210,7 +189,7 @@ class ShelveryEBSIntegrationTestCase(unittest.TestCase):
             traceback.print_exc(file=sys.stdout)
             raise e
         ec2client = boto3.client('ec2')
-
+        
         valid = False
         # validate there is
         for backup in backups:
@@ -221,17 +200,30 @@ class ShelveryEBSIntegrationTestCase(unittest.TestCase):
                 ec2client.create_tags(
                     Resources=[snapshot_id],
                     Tags=[{'Key': f"{RuntimeConfig.get_tag_prefix()}:date_created",
-                           'Value': datetime(1990, 1, 1).strftime(BackupResource.TIMESTAMP_FORMAT)
+                           'Value': datetime(2000, 1, 1).strftime(BackupResource.TIMESTAMP_FORMAT)
                            }]
                 )
                 ebs_backups_engine.clean_backups()
                 with self.assertRaises(botocore.exceptions.ClientError) as context:
                     ec2client.describe_snapshots(SnapshotIds=[snapshot_id])['Snapshots']
-
+                
                 self.assertTrue('does not exist' in context.exception.response['Error']['Message'])
                 self.assertEqual('InvalidSnapshot.NotFound', context.exception.response['Error']['Code'])
+                
+                account_id = ebs_backups_engine.account_id
+                s3path = f"{S3_DATA_PREFIX}/{ebs_backups_engine.get_engine_type()}/removed/{backup.name}.yaml"
+                s3bucket = ShelveryEngine.get_local_bucket_name()
+                bucket = boto3.resource('s3').Bucket(s3bucket)
+                object = bucket.Object(s3path)
+                content = object.get()['Body'].read()
+                restored_br = yaml.load(content)
+                self.assertEquals(restored_br.backup_id, backup.backup_id)
+                self.assertEquals(restored_br.name, backup.name)
+                self.assertEquals(restored_br.region, backup.region)
+                self.assertIsNotNone(restored_br.date_deleted)
+                self.assertEquals(restored_br.date_created, datetime(2000, 1, 1))
                 valid = True
-
+        
         self.assertTrue(valid)
 
 


### PR DESCRIPTION
# Improvements / bug fixes

- Entities with special characters are translated into backup names with only allowed alphanumeric characters and hyphens. Consecutive hyphens are squashed into single character.

- Backup names are including hash of entity name, avoiding name collision of entities with different resource ids, but same names

# New features

- Backup data is being written to S3 bucket, including sharing info. 
- Above sharing info from S3 is used to 'pull shared backups' - that is copy backups from originating account into account where shelvery is running. This feature has been implemented for all 4 currently supported engines (ebs, ec2ami, rds, rds_cluster)

