### PR TITLE
fully parametrise cron schedule for serverless deployments

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -97,93 +97,102 @@ functions:
     runtime: python3.6
     timeout: 300
     events:
+
+      ## Create backups schedule
+
       # create buckets
       - schedule:
-          rate: 'cron(0 0 ? * * *)'
+          rate: ${env:shelvery_create_buckets,'cron(0 0 ? * * *)'}
           enabled: true
           input:
             backup_type: ebs
             action: create_data_buckets
       # create ebs
       - schedule:
-          rate: 'cron(0 1 ? * * *)'
+          rate: ${env:shelvery_create_cron,'cron(0 1 ? * * *)'}
           enabled: true
           input:
             backup_type: ebs
             action: create_backups
       # create rds
       - schedule:
-          rate: 'cron(0 1 ? * * *)'
+          rate: ${env:shelvery_create_cron,'cron(0 1 ? * * *)'}
           enabled: true
           input:
             backup_type: rds
             action: create_backups
       # create rds cluster
       - schedule:
-          rate: 'cron(0 1 ? * * *)'
+          rate: ${env:shelvery_create_cron,'cron(0 1 ? * * *)'}
           enabled: true
           input:
             backup_type: rds_cluster
             action: create_backups
       # create ec2 amis
       - schedule:
-          rate: 'cron(0 1 ? * * *)'
+          rate: ${env:shelvery_create_cron,'cron(0 1 ? * * *)'}
           enabled: true
           input:
             backup_type: ec2ami
             action: create_backups
+
+      ## Clean backups schedule ##
+
       # clean ebs
       - schedule:
-          rate: 'cron(0 2 ? * * *)'
+          rate: ${env:shelvery_clean_cron,'cron(0 2 ? * * *)'}
           enabled: true
           input:
             backup_type: ebs
             action: clean_backups
       # clean rds
       - schedule:
-          rate: 'cron(0 2 ? * * *)'
+          rate: ${env:shelvery_clean_cron,'cron(0 2 ? * * *)'}
           enabled: true
           input:
             backup_type: rds
             action: clean_backups
       # clean rds cluster
       - schedule:
-          rate: 'cron(0 2 ? * * *)'
+          rate: ${env:shelvery_clean_cron,'cron(0 2 ? * * *)'}
           enabled: true
           input:
             backup_type: rds_cluster
             action: clean_backups
-      # pull amis
+      # clean amis
       - schedule:
-          rate: 'cron(0 2 ? * * *)'
+          rate: ${env:shelvery_clean_cron,'cron(0 2 ? * * *)'}
           enabled: true
           input:
             backup_type: ec2ami
             action: clean_backups
+
+      ### Pull shared backups ####
+
       # pull ebs
       - schedule:
-          rate: 'cron(0 2 ? * * *)'
+          rate: ${env:shelvery_pull_cron,'cron(0 2 ? * * *)'}
           enabled: true
           input:
             backup_type: ebs
             action: pull_shared_backups
       # pull rds
       - schedule:
-          rate: 'cron(0 2 ? * * *)'
+          rate: ${env:shelvery_pull_cron,'cron(0 2 ? * * *)'}
           enabled: true
           input:
             backup_type: rds
             action: pull_shared_backups
       # pull rds cluster
       - schedule:
-          rate: 'cron(0 2 ? * * *)'
+          rate: ${env:shelvery_pull_cron,'cron(0 2 ? * * *)'}
           enabled: true
           input:
             backup_type: rds_cluster
             action: pull_shared_backups
       # pull amis
       - schedule:
-          rate: 'cron(0 2 ? * * *)'
+          rate: ${env:shelvery_pull_cron,'cron(0 2 ? * * *)'}
           enabled: true
           input:
             backup_type: ec2ami
@@ -195,4 +204,5 @@ functions:
       shelvery_keep_yearly_backups: ${env:shelvery_keep_yearly_backups,'10'}
       shelvery_dr_regions: ${env:shelvery_dr_regions,''}
       shelvery_share_aws_account_ids: ${env:shelvery_share_aws_account_ids,''}
+      shelvery_source_aws_account_ids: ${env:shelvery_source_aws_account_ids,''}
       shelvery_rds_backup_mode: ${env:shelvery_rds_backup_mode,'RDS_COPY_AUTOMATED_SNAPSHOT'}


### PR DESCRIPTION
Idea is that serverless deployments of shelvery system can be parametrised, and schedules fine tuned with some sane defaults. Defaults are as following

- Make sure that data bucket is present 00:00 CET
- Create backups at 01:00 CET
- Cleanup backups at 02:00 CET
- Pull shared backups at 02:00 CET (gives full hour to backup creation process)