### PR TITLE
boto retry config defaults to 10 retries

### DIFF
--- a/shelvery/aws_helper.py
+++ b/shelvery/aws_helper.py
@@ -1,5 +1,8 @@
 import json
 import boto3
+from botocore.config import Config
+
+from shelvery.runtime_config import RuntimeConfig
 from shelvery import S3_DATA_PREFIX
 
 
@@ -46,8 +49,22 @@ class AwsHelper:
 
     @staticmethod
     def local_account_id():
-        return boto3.client('sts').get_caller_identity()['Account']
+        return AwsHelper.boto3_client('sts').get_caller_identity()['Account']
 
     @staticmethod
     def local_region():
         return boto3.session.Session().region_name
+    
+    @staticmethod
+    def boto3_retry_config():
+        return RuntimeConfig.boto3_retry_times()
+        
+    @staticmethod
+    def boto3_client(service_name, region_name = None):
+        if region_name is None:
+            region_name = AwsHelper.local_region()
+            
+        return boto3.client(service_name,
+                            region_name=region_name,
+                            config=Config(retries={'max_attempts':AwsHelper.boto3_retry_config()}))
+    

--- a/shelvery/ebs_backup.py
+++ b/shelvery/ebs_backup.py
@@ -3,7 +3,7 @@ import boto3
 from typing import List
 
 from botocore.exceptions import ClientError
-
+from shelvery.aws_helper import AwsHelper
 from shelvery.engine import SHELVERY_DO_BACKUP_TAGS
 from shelvery.ec2_backup import ShelveryEC2Backup
 from shelvery.entity_resource import EntityResource
@@ -79,7 +79,7 @@ class ShelveryEBSBackup(ShelveryEC2Backup):
     
     def is_backup_available(self, region: str, backup_id: str) -> bool:
         try:
-            regional_client = boto3.client('ec2', region_name=region)
+            regional_client = AwsHelper.boto3_client('ec2', region_name=region)
             snapshot = regional_client.describe_snapshots(SnapshotIds=[backup_id])['Snapshots'][0]
             complete = snapshot['State'] == 'completed'
             self.logger.info(f"{backup_id} is {snapshot['Progress']} complete")
@@ -89,7 +89,7 @@ class ShelveryEBSBackup(ShelveryEC2Backup):
     
     def copy_backup_to_region(self, backup_id: str, region: str):
         snapshot = self.ec2client.describe_snapshots(SnapshotIds=[backup_id])['Snapshots'][0]
-        regional_client = boto3.client('ec2', region_name=region)
+        regional_client = AwsHelper.boto3_client('ec2', region_name=region)
         copy_snapshot_response = regional_client.copy_snapshot(SourceSnapshotId=backup_id,
                                                                SourceRegion=self.ec2client._client_config.region_name,
                                                                DestinationRegion=region,

--- a/shelvery/ec2_backup.py
+++ b/shelvery/ec2_backup.py
@@ -3,7 +3,7 @@ import boto3
 from shelvery.backup_resource import BackupResource
 from shelvery.engine import ShelveryEngine
 from shelvery.entity_resource import EntityResource
-
+from shelvery.aws_helper import AwsHelper
 from typing import Dict, List
 
 
@@ -12,12 +12,12 @@ class ShelveryEC2Backup(ShelveryEngine):
     
     def __init__(self):
         ShelveryEngine.__init__(self)
-        self.ec2client = boto3.client('ec2')
-        # default region will be picked up in boto3.client call
+        self.ec2client = AwsHelper.boto3_client('ec2')
+        # default region will be picked up in AwsHelper.boto3_client call
         self.region = boto3.session.Session().region_name
 
     def tag_backup_resource(self, backup_resource: BackupResource):
-        regional_client = boto3.client('ec2', region_name=backup_resource.region)
+        regional_client = AwsHelper.boto3_client('ec2', region_name=backup_resource.region)
         regional_client.create_tags(
             Resources=[backup_resource.backup_id],
             Tags=list(map(lambda k: {'Key': k, 'Value': backup_resource.tags[k]}, backup_resource.tags))

--- a/shelvery/ec2ami_backup.py
+++ b/shelvery/ec2ami_backup.py
@@ -13,7 +13,7 @@ from shelvery.engine import SHELVERY_DO_BACKUP_TAGS
 
 class ShelveryEC2AMIBackup(ShelveryEC2Backup):
     def delete_backup(self, backup_resource: BackupResource):
-        regional_client = boto3.client('ec2', region_name=backup_resource.region)
+        regional_client = AwsHelper.boto3_client('ec2', region_name=backup_resource.region)
         ami = regional_client.describe_images(ImageIds=[backup_resource.backup_id])['Images'][0]
         
         # delete image
@@ -64,7 +64,7 @@ class ShelveryEC2AMIBackup(ShelveryEC2Backup):
         return ami['ImageId']
     
     def backup_resource(self, backup_resource: BackupResource):
-        regional_client = boto3.client('ec2', region_name=backup_resource.region)
+        regional_client = AwsHelper.boto3_client('ec2', region_name=backup_resource.region)
         ami = regional_client.create_image(
             NoReboot=True,
             Name=backup_resource.name,
@@ -124,7 +124,7 @@ class ShelveryEC2AMIBackup(ShelveryEC2Backup):
         return entities
     
     def is_backup_available(self, backup_region: str, backup_id: str) -> bool:
-        regional_client = boto3.client('ec2', region_name=backup_region)
+        regional_client = AwsHelper.boto3_client('ec2', region_name=backup_region)
         ami = regional_client.describe_images(ImageIds=[backup_id])
         if len(ami['Images']) > 0:
             return ami['Images'][0]['State'] == 'available'
@@ -133,8 +133,8 @@ class ShelveryEC2AMIBackup(ShelveryEC2Backup):
     
     def copy_backup_to_region(self, backup_id: str, region: str) -> str:
         local_region = boto3.session.Session().region_name
-        local_client = boto3.client('ec2', region_name=local_region)
-        regional_client = boto3.client('ec2', region_name=region)
+        local_client = AwsHelper.boto3_client('ec2', region_name=local_region)
+        regional_client = AwsHelper.boto3_client('ec2', region_name=region)
         ami = local_client.describe_images(ImageIds=[backup_id])['Images'][0]
         idempotency_token = f"shelverycopy{backup_id.replace('-','')}to{region.replace('-','')}"
         return regional_client.copy_image(Name=ami['Name'],

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -84,13 +84,13 @@ class ShelveryEngine:
 
         s3 = boto3.resource('s3')
         try:
-            boto3.client('s3').head_bucket(Bucket=bucket_name)
+            AwsHelper.boto3_client('s3').head_bucket(Bucket=bucket_name)
             bucket = s3.Bucket(bucket_name)
 
         except ClientError as e:
             if e.response['Error']['Code'] == '404':
                 client_region = loc_constraint
-                s3client = boto3.client('s3', region_name=client_region)
+                s3client = AwsHelper.boto3_client('s3', region_name=client_region)
                 if loc_constraint == "us-east-1":
                     bucket = s3client.create_bucket(Bucket=bucket_name)
                 else:
@@ -269,7 +269,7 @@ class ShelveryEngine:
     def pull_shared_backups(self):
 
         account_id = self.account_id
-        s3_client = boto3.client('s3')
+        s3_client = AwsHelper.boto3_client('s3')
         for src_account_id in RuntimeConfig.get_source_backup_accounts(self):
             try:
                 bucket_name = self.get_remote_bucket_name(src_account_id)
@@ -282,8 +282,8 @@ class ShelveryEngine:
                     bucket_region = 'eu-west-1'
                 elif bucket_region is None:
                     bucket_region = 'us-east-1'
-                regional_client = boto3.client('s3', region_name=bucket_region)
-
+                regional_client = AwsHelper.boto3_client('s3', region_name=bucket_region)
+                
                 shared_backups = regional_client.list_objects_v2(Bucket=bucket_name, Prefix=path)
                 if 'Contents' in shared_backups:
                     all_backups = shared_backups['Contents']
@@ -359,7 +359,7 @@ class ShelveryEngine:
         regions.extend(RuntimeConfig.get_dr_regions(None, self))
         for region in regions:
             bucket = self._get_data_bucket(region)
-            boto3.client('s3', region_name=region).put_bucket_policy(Bucket=bucket.name,
+            AwsHelper.boto3_client('s3', region_name=region).put_bucket_policy(Bucket=bucket.name,
                                                  Policy=AwsHelper.get_shelvery_bucket_policy(
                                                      self.account_id,
                                                      RuntimeConfig.get_share_with_accounts(self),

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -137,11 +137,6 @@ class ShelveryEngine:
         self.logger.info(f"Wrote meta for backup {backup.name} of type {self.get_engine_type()} to" +
                          f" s3://{bucket.name}/{s3key}")
 
-    def _get_shelvery_shared_backups(self):
-        account_id = RuntimeConfig.get_aws_account_id()
-        for account_id in RuntimeConfig.get_source_backup_accounts(self):
-            bucket = self._get_data_bucket(account_id)
-            path = f"{S3_DATA_PREFIX}/{self.get_engine_type()}/shared/{account_id}"
 
     ### Top level methods, invoked externally ####
     def create_backups(self) -> List[BackupResource]:

--- a/shelvery/notifications.py
+++ b/shelvery/notifications.py
@@ -1,7 +1,7 @@
 import boto3
 import json
 import logging
-
+from shelvery.aws_helper import AwsHelper
 from datetime import datetime
 
 logger = logging.getLogger(__name__)
@@ -12,7 +12,7 @@ class ShelveryNotification:
     def __init__(self, topic_arn):
         self.topic_arn = topic_arn
         logger.info("Initialized notification service")
-        self.sns = boto3.client('sns')
+        self.sns = AwsHelper.boto3_client('sns')
     
     def notify(self, message):
         if isinstance(message, dict):

--- a/shelvery/rds_cluster_backup.py
+++ b/shelvery/rds_cluster_backup.py
@@ -7,11 +7,11 @@ from shelvery.entity_resource import EntityResource
 
 from typing import Dict, List
 from botocore.errorfactory import ClientError
-
+from shelvery.aws_helper import AwsHelper
 
 class ShelveryRDSClusterBackup(ShelveryEngine):
     def is_backup_available(self, backup_region: str, backup_id: str) -> bool:
-        rds_client = boto3.client('rds', region_name=backup_region)
+        rds_client = AwsHelper.boto3_client('rds', region_name=backup_region)
         snapshots = rds_client.describe_db_cluster_snapshots(DBClusterSnapshotIdentifier=backup_id)
         return snapshots['DBClusterSnapshots'][0]['Status'] == 'available'
     
@@ -30,7 +30,7 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
                         f"modes supported - set rds backup mode using rds_backup_mode configuration option ")
     
     def backup_from_latest_automated(self, backup_resource: BackupResource):
-        rds_client = boto3.client('rds')
+        rds_client = AwsHelper.boto3_client('rds')
         auto_snapshots = rds_client.describe_db_cluster_snapshots(
             DBClusterIdentifier=backup_resource.entity_id,
             SnapshotType='automated',
@@ -56,7 +56,7 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
         return backup_resource
     
     def backup_from_cluster(self, backup_resource):
-        rds_client = boto3.client('rds')
+        rds_client = AwsHelper.boto3_client('rds')
         rds_client.create_db_cluster_snapshot(
             DBClusterSnapshotIdentifier=backup_resource.name,
             DBClusterIdentifier=backup_resource.entity_id
@@ -65,13 +65,13 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
         return backup_resource
     
     def delete_backup(self, backup_resource: BackupResource):
-        rds_client = boto3.client('rds')
+        rds_client = AwsHelper.boto3_client('rds')
         rds_client.delete_db_cluster_snapshot(
             DBClusterSnapshotIdentifier=backup_resource.backup_id
         )
     
     def tag_backup_resource(self, backup_resource: BackupResource):
-        regional_rds_client = boto3.client('rds', region_name=backup_resource.region)
+        regional_rds_client = AwsHelper.boto3_client('rds', region_name=backup_resource.region)
         snapshots = regional_rds_client.describe_db_cluster_snapshots(
             DBClusterSnapshotIdentifier=backup_resource.backup_id)
         snapshot_arn = snapshots['DBClusterSnapshots'][0]['DBClusterSnapshotArn']
@@ -82,7 +82,7 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
         )
     
     def get_existing_backups(self, backup_tag_prefix: str) -> List[BackupResource]:
-        rds_client = boto3.client('rds')
+        rds_client = AwsHelper.boto3_client('rds')
         
         # collect all snapshots
         all_snapshots = self.collect_all_snapshots(rds_client)
@@ -93,7 +93,7 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
         return all_backups
     
     def share_backup_with_account(self, backup_region: str, backup_id: str, aws_account_id: str):
-        rds_client = boto3.client('rds', region_name=backup_region)
+        rds_client = AwsHelper.boto3_client('rds', region_name=backup_region)
         rds_client.modify_db_cluster_snapshot_attribute(
             DBClusterSnapshotIdentifier=backup_id,
             AttributeName='restore',
@@ -102,8 +102,8 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
     
     def copy_backup_to_region(self, backup_id: str, region: str) -> str:
         local_region = boto3.session.Session().region_name
-        client_local = boto3.client('rds')
-        rds_client = boto3.client('rds', region_name=region)
+        client_local = AwsHelper.boto3_client('rds')
+        rds_client = AwsHelper.boto3_client('rds', region_name=region)
         snapshots = client_local.describe_db_cluster_snapshots(DBClusterSnapshotIdentifier=backup_id)
         snapshot = snapshots['DBClusterSnapshots'][0]
         rds_client.copy_db_cluster_snapshot(
@@ -116,7 +116,7 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
         return backup_id
 
     def copy_shared_backup(self, source_account: str, source_backup: BackupResource):
-        rds_client = boto3.client('rds')
+        rds_client = AwsHelper.boto3_client('rds')
         # copying of tags happens outside this method
         source_arn = f"arn:aws:rds:{source_backup.region}:{source_backup.account_id}:cluster-snapshot:{source_backup.backup_id}"
         snap = rds_client.copy_db_cluster_snapshot(
@@ -128,7 +128,7 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
         return snap['DBClusterSnapshot']['DBClusterSnapshotIdentifier']
     
     def get_backup_resource(self, backup_region: str, backup_id: str) -> BackupResource:
-        rds_client = boto3.client('rds', region_name=backup_region)
+        rds_client = AwsHelper.boto3_client('rds', region_name=backup_region)
         snapshots = rds_client.describe_db_cluster_snapshots(DBClusterSnapshotIdentifier=backup_id)
         snapshot = snapshots['DBClusterSnapshots'][0]
         tags = rds_client.list_tags_for_resource(ResourceName=snapshot['DBClusterSnapshotArn'])['TagList']
@@ -141,7 +141,7 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
     def get_entities_to_backup(self, tag_name: str) -> List[EntityResource]:
         # region and api client
         local_region = boto3.session.Session().region_name
-        rds_client = boto3.client('rds')
+        rds_client = AwsHelper.boto3_client('rds')
         
         # list of models returned from api
         db_cluster_entities = []
@@ -230,7 +230,7 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
             if snap['DBClusterIdentifier'] not in cluster_ids:
                 cluster_ids.append(snap['DBClusterIdentifier'])
         entities = {}
-        rds_client = boto3.client('rds')
+        rds_client = AwsHelper.boto3_client('rds')
         local_region = boto3.session.Session().region_name
         
         for cluster_id in cluster_ids:

--- a/shelvery/redshift_backup.py
+++ b/shelvery/redshift_backup.py
@@ -9,12 +9,13 @@ from shelvery.engine import ShelveryEngine
 from shelvery.entity_resource import EntityResource
 from shelvery.runtime_config import RuntimeConfig
 from shelvery.backup_resource import BackupResource
+from shelvery.aws_helper import AwsHelper
 
 class ShelveryRedshiftBackup(ShelveryEngine):
 	def __init__(self):
 		ShelveryEngine.__init__(self)
-		self.redshift_client = boto3.client('redshift')
-		# default region will be picked up in boto3.client call
+		self.redshift_client = AwsHelper.boto3_client('redshift')
+		# default region will be picked up in AwsHelper.boto3_client call
 		self.region = boto3.session.Session().region_name
 
 	def get_resource_type(self) -> str:
@@ -31,7 +32,7 @@ class ShelveryRedshiftBackup(ShelveryEngine):
 		"""
 		Remove given backup from system
 		"""
-		redshift_client = boto3.client('redshift', region_name = backup_resource.region)
+		redshift_client = AwsHelper.boto3_client('redshift', region_name = backup_resource.region)
 		cluster_id = backup_resource.backup_id.split(":")[-1].split("/")[0]
 		snapshot_id = backup_resource.backup_id.split(":")[-1].split("/")[1]
 		try:
@@ -178,7 +179,7 @@ class ShelveryRedshiftBackup(ShelveryEngine):
 		Create backup resource tags.
 		"""
 		# This is unnecessary for Redshift as the tags are included when calling `backup_resource()`.
-		redshift_client = boto3.client('redshift', region_name = backup_resource.region)
+		redshift_client = AwsHelper.boto3_client('redshift', region_name = backup_resource.region)
 		redshift_client.create_tags(
 			ResourceName=backup_resource.backup_id,
 			Tags=backup_resource.boto3_tags
@@ -200,7 +201,7 @@ class ShelveryRedshiftBackup(ShelveryEngine):
 		Determine whether backup has completed and is available to be copied
 		to other regions and shared with other AWS accounts
 		"""
-		redshift_client = boto3.client('redshift', region_name=backup_region)
+		redshift_client = AwsHelper.boto3_client('redshift', region_name=backup_region)
 		snapshot_id = backup_id.split(":")[-1].split("/")[1]
 		snapshots = None
 		try:
@@ -222,7 +223,7 @@ class ShelveryRedshiftBackup(ShelveryEngine):
 		"""
 		Share backup with another AWS Account
 		"""
-		redshift_client = boto3.client('redshift', region_name=backup_region)
+		redshift_client = AwsHelper.boto3_client('redshift', region_name=backup_region)
 		snapshot_id = backup_id.split(":")[-1].split("/")[1]
 		redshift_client.authorize_snapshot_access(
 			SnapshotIdentifier=snapshot_id,
@@ -234,7 +235,7 @@ class ShelveryRedshiftBackup(ShelveryEngine):
 		"""
 		Get Backup Resource within region, identified by its backup_id
 		"""
-		redshift_client = boto3.client('redshift', region_name=backup_region)
+		redshift_client = AwsHelper.boto3_client('redshift', region_name=backup_region)
 		snapshot_id = backup_id.split(":")[-1].split("/")[1]
 		snapshots = redshift_client.describe_cluster_snapshots(SnapshotIdentifier=snapshot_id)
 		snapshot = snapshots['Snapshots'][0]

--- a/shelvery/runtime_config.py
+++ b/shelvery/runtime_config.py
@@ -2,7 +2,6 @@ import re
 import os
 import boto3
 
-from shelvery.aws_helper import AwsHelper
 
 
 class RuntimeConfig:
@@ -228,10 +227,6 @@ class RuntimeConfig:
             return None
         return val
 
-    @classmethod
-    def get_aws_account_id(cls):
-        # TODO cache
-        return AwsHelper.boto3_client('sts').get_caller_identity()['Account']
 
     @classmethod
     def get_sns_topic(cls, engine):

--- a/shelvery/runtime_config.py
+++ b/shelvery/runtime_config.py
@@ -2,6 +2,8 @@ import re
 import os
 import boto3
 
+from shelvery.aws_helper import AwsHelper
+
 
 class RuntimeConfig:
     """
@@ -69,7 +71,8 @@ class RuntimeConfig:
         'shelvery_source_aws_account_ids': None,
         'shelvery_share_aws_account_ids': None,
         'shelvery_redshift_backup_mode': REDSHIFT_COPY_AUTOMATED_SNAPSHOT,
-        'shelvery_select_entity': None
+        'shelvery_select_entity': None,
+        'boto3_retries': 10
     }
 
     @classmethod
@@ -228,11 +231,15 @@ class RuntimeConfig:
     @classmethod
     def get_aws_account_id(cls):
         # TODO cache
-        return boto3.client('sts').get_caller_identity()['Account']
+        return AwsHelper.boto3_client('sts').get_caller_identity()['Account']
 
     @classmethod
     def get_sns_topic(cls, engine):
         return cls.get_conf_value('shelvery_sns_topic', None, engine.lambda_payload)
+
+    @classmethod
+    def boto3_retry_times(cls):
+        return cls.get_conf_value('boto3_retries', None, None)
 
     @classmethod
     def get_error_sns_topic(cls, engine):

--- a/shelvery/shelvery_invoker.py
+++ b/shelvery/shelvery_invoker.py
@@ -7,13 +7,13 @@ from typing import Dict
 from threading import Thread
 
 from shelvery.runtime_config import RuntimeConfig
-
+from shelvery.aws_helper import AwsHelper
 
 class ShelveryInvoker:
     """Helper to orchestrate execution of shelvery operations on AWS Lambda platform"""
     
     def __init__(self):
-        self.lambda_client = boto3.client('lambda')
+        self.lambda_client = AwsHelper.boto3_client('lambda')
     
     def invoke_shelvery_operation(self, engine, method_name: str, method_arguments: Dict):
         """

--- a/shelvery_tests/ebs_integration_test.py
+++ b/shelvery_tests/ebs_integration_test.py
@@ -20,6 +20,7 @@ from shelvery.ebs_backup import ShelveryEBSBackup
 from shelvery.engine import ShelveryEngine
 from shelvery.runtime_config import RuntimeConfig
 from shelvery.backup_resource import BackupResource
+from shelvery.aws_helper import AwsHelper
 
 print(f"Python lib path:\n{sys.path}")
 
@@ -42,8 +43,8 @@ class ShelveryEBSIntegrationTestCase(unittest.TestCase):
         print("Create EBS Volume of 1G")
         os.environ['AWS_DEFAULT_REGION'] = 'us-east-1'
         os.environ['SHELVERY_MONO_THREAD'] = '1'
-        ec2client = boto3.client('ec2')
-        sts = boto3.client('sts')
+        ec2client = AwsHelper.boto3_client('ec2')
+        sts = AwsHelper.boto3_client('sts')
         self.id = sts.get_caller_identity()
         print(f"Running as user:\n{self.id}\n")
         self.volume = ec2client.create_volume(AvailabilityZone='us-east-1a',
@@ -70,7 +71,7 @@ class ShelveryEBSIntegrationTestCase(unittest.TestCase):
         os.environ['shelvery_select_entity'] = self.volume['VolumeId']
 
     def tearDown(self):
-        ec2client = boto3.client('ec2')
+        ec2client = AwsHelper.boto3_client('ec2')
         ec2client.delete_volume(VolumeId=self.volume['VolumeId'])
         print(f"Deleted volume:\n{self.volume['VolumeId']}\n")
 
@@ -84,7 +85,7 @@ class ShelveryEBSIntegrationTestCase(unittest.TestCase):
                 print(f"Failed to delete {snapid}:{str(e)}")
 
         for region in self.regional_snapshots:
-            ec2regional = boto3.client('ec2', region_name=region)
+            ec2regional = AwsHelper.boto3_client('ec2', region_name=region)
             for snapid in self.regional_snapshots[region]:
                 try:
                     ec2regional.delete_snapshot(SnapshotId=snapid)
@@ -100,7 +101,7 @@ class ShelveryEBSIntegrationTestCase(unittest.TestCase):
             print(f"Failed with {e}")
             traceback.print_exc(file=sys.stdout)
             raise e
-        ec2client = boto3.client('ec2')
+        ec2client = AwsHelper.boto3_client('ec2')
 
         valid = False
         # validate there is
@@ -165,7 +166,7 @@ class ShelveryEBSIntegrationTestCase(unittest.TestCase):
         finally:
             del os.environ["shelvery_dr_regions"]
 
-        ec2dr_region = boto3.client('ec2', region_name='us-west-2')
+        ec2dr_region = AwsHelper.boto3_client('ec2', region_name='us-west-2')
         valid = False
         # validate there is
         for backup in backups:
@@ -209,7 +210,7 @@ class ShelveryEBSIntegrationTestCase(unittest.TestCase):
             print(f"Failed with {e}")
             traceback.print_exc(file=sys.stdout)
             raise e
-        ec2client = boto3.client('ec2')
+        ec2client = AwsHelper.boto3_client('ec2')
 
         valid = False
         # validate there is

--- a/shelvery_tests/name_transformation_test.py
+++ b/shelvery_tests/name_transformation_test.py
@@ -21,6 +21,7 @@ from shelvery.engine import ShelveryEngine
 from shelvery.engine import S3_DATA_PREFIX
 from shelvery.runtime_config import RuntimeConfig
 from shelvery.backup_resource import BackupResource
+from shelvery.aws_helper import AwsHelper
 
 print(f"Python lib path:\n{sys.path}")
 
@@ -45,8 +46,8 @@ class ShelveryNameTransformationTestCase(unittest.TestCase):
         print("Create EBS Volume of 1G")
         os.environ['AWS_DEFAULT_REGION'] = 'us-east-1'
         os.environ['SHELVERY_MONO_THREAD'] = '1'
-        ec2client = boto3.client('ec2')
-        sts = boto3.client('sts')
+        ec2client = AwsHelper.boto3_client('ec2')
+        sts = AwsHelper.boto3_client('sts')
         self.id = sts.get_caller_identity()
         print(f"Running as user:\n{self.id}\n")
         self.volume = ec2client.create_volume(AvailabilityZone='us-east-1a',
@@ -73,7 +74,7 @@ class ShelveryNameTransformationTestCase(unittest.TestCase):
         os.environ['shelvery_select_entity'] = self.volume['VolumeId']
     
     def tearDown(self):
-        ec2client = boto3.client('ec2')
+        ec2client = AwsHelper.boto3_client('ec2')
         ec2client.delete_volume(VolumeId=self.volume['VolumeId'])
         print(f"Deleted volume:\n{self.volume['VolumeId']}\n")
         
@@ -87,7 +88,7 @@ class ShelveryNameTransformationTestCase(unittest.TestCase):
                 print(f"Failed to delete {snapid}:{str(e)}")
         
         for region in self.regional_snapshots:
-            ec2regional = boto3.client('ec2', region_name=region)
+            ec2regional = AwsHelper.boto3_client('ec2', region_name=region)
             for snapid in self.regional_snapshots[region]:
                 try:
                     ec2regional.delete_snapshot(SnapshotId=snapid)
@@ -103,7 +104,7 @@ class ShelveryNameTransformationTestCase(unittest.TestCase):
             print(f"Failed with {e}")
             traceback.print_exc(file=sys.stdout)
             raise e
-        ec2client = boto3.client('ec2')
+        ec2client = AwsHelper.boto3_client('ec2')
         
         valid = False
         # validate there is

--- a/shelvery_tests/s3data_integration_test.py
+++ b/shelvery_tests/s3data_integration_test.py
@@ -21,6 +21,8 @@ from shelvery.engine import ShelveryEngine
 from shelvery.engine import S3_DATA_PREFIX
 from shelvery.runtime_config import RuntimeConfig
 from shelvery.backup_resource import BackupResource
+from shelvery.aws_helper import AwsHelper
+
 
 print(f"Python lib path:\n{sys.path}")
 
@@ -43,8 +45,8 @@ class ShelveryS3DataTestCase(unittest.TestCase):
         print("Create EBS Volume of 1G")
         os.environ['AWS_DEFAULT_REGION'] = 'us-east-1'
         os.environ['SHELVERY_MONO_THREAD'] = '1'
-        ec2client = boto3.client('ec2')
-        sts = boto3.client('sts')
+        ec2client = AwsHelper.boto3_client('ec2')
+        sts = AwsHelper.boto3_client('sts')
         self.id = sts.get_caller_identity()
         print(f"Running as user:\n{self.id}\n")
         self.volume = ec2client.create_volume(AvailabilityZone='us-east-1a',
@@ -71,7 +73,7 @@ class ShelveryS3DataTestCase(unittest.TestCase):
         os.environ['shelvery_select_entity'] = self.volume['VolumeId']
     
     def tearDown(self):
-        ec2client = boto3.client('ec2')
+        ec2client = AwsHelper.boto3_client('ec2')
         ec2client.delete_volume(VolumeId=self.volume['VolumeId'])
         print(f"Deleted volume:\n{self.volume['VolumeId']}\n")
         
@@ -85,7 +87,7 @@ class ShelveryS3DataTestCase(unittest.TestCase):
                 print(f"Failed to delete {snapid}:{str(e)}")
         
         for region in self.regional_snapshots:
-            ec2regional = boto3.client('ec2', region_name=region)
+            ec2regional = AwsHelper.boto3_client('ec2', region_name=region)
             for snapid in self.regional_snapshots[region]:
                 try:
                     ec2regional.delete_snapshot(SnapshotId=snapid)
@@ -101,7 +103,7 @@ class ShelveryS3DataTestCase(unittest.TestCase):
             print(f"Failed with {e}")
             traceback.print_exc(file=sys.stdout)
             raise e
-        ec2client = boto3.client('ec2')
+        ec2client = AwsHelper.boto3_client('ec2')
         
         valid = False
         # validate there is
@@ -188,7 +190,7 @@ class ShelveryS3DataTestCase(unittest.TestCase):
             print(f"Failed with {e}")
             traceback.print_exc(file=sys.stdout)
             raise e
-        ec2client = boto3.client('ec2')
+        ec2client = AwsHelper.boto3_client('ec2')
         
         valid = False
         # validate there is


### PR DESCRIPTION
introduces `AwsHelper.boto3_client` "factory" method for producing boto3 clients with default configuration, including retry configuration. Allow configuring retry configuration through environment variables. 