### PR TITLE
Support cross-account copying of encrypted RDS cluster snapshots.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Shelvery *does not* cater for backup restore process.
 - Create and clean Redshift manual backups
 - Get notified about all operations performed by Shelvery via SNS Topic
 - Share backups with other accounts automatically
-- Copying backups shared by other AWS accounts automatically
+- Copying backups shared by other AWS accounts automatically, enabling a *data bunker* setup
 - Copy backups to disaster recovery AWS regions
 - Multiple levels of configuration, with priorities: Resource tags, Lambda payload, Environment Variables, Config defaults
 
@@ -278,7 +278,7 @@ Available configuration keys are listed below:
 - `shelvery_dr_regions` - List of disaster recovery regions, comma separated
 - `shelvery_wait_snapshot_timeout` - Timeout in seconds to wait for snapshot to become available before copying it
 to another region or sharing with other account. Defaults to 1200 (20 minutes)
-- `shelvery_share_aws_account_ids` -  AWS Account Ids to share backups with. Applies to both original and regional backups                                                                   
+- `shelvery_share_aws_account_ids` -  AWS Account Ids to share backups with. Applies to both original and regional backups
 - `shelvery_source_aws_account_ids` - List of AWS Account Ids, comma seperated, that are exposing/sharing their shelvery
     backups with account where shelvery is running. This can be used for having DR aws account that aggregates backups
     from other accounts.
@@ -390,6 +390,14 @@ $ export shelvery_source_aws_account_ids=222222222222,333333333333
 # this command will pull backups from both accounts
 $ shelvery ebs pull_shared_backups
 ```
+
+## Cross-account copying of encrypted backups
+
+Shelvery enables the sharing and copying of encrypted backups between accounts. In order to configure this, you must share the backup's KMS key and follow the instructions in step #2 above.
+For instructions on how to share the KMS key, see https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ShareSnapshot.html
+
+This is currently only supported for:
+  - RDS clusters
 
 ## Waiting on backups to complete
 

--- a/shelvery/backup_resource.py
+++ b/shelvery/backup_resource.py
@@ -24,7 +24,7 @@ class BackupResource:
     RETENTION_MONTHLY = 'monthly'
     RETENTION_YEARLY = 'yearly'
 
-    def __init__(self, tag_prefix, entity_resource: EntityResource, construct=False, copy_resource_tags=True, exluded_resource_tag_keys=[]):
+    def __init__(self, tag_prefix, entity_resource: EntityResource, construct=False, copy_resource_tags=True, exluded_resource_tag_keys=[], resource_properties={}):
         """Construct new backup resource out of entity resource (e.g. ebs volume)."""
         # if object manually created
         if construct:
@@ -86,6 +86,7 @@ class BackupResource:
         self.backup_id = None
         self.expire_date = None
         self.date_deleted = None
+        self.resource_properties = resource_properties
 
     def cross_account_copy(self, new_backup_id):
         backup = copy.deepcopy(self)

--- a/shelvery/runtime_config.py
+++ b/shelvery/runtime_config.py
@@ -233,7 +233,7 @@ class RuntimeConfig:
                 shelvery.logger.warn(f"Account id {acc} is not 12-digit number, skipping for share")
             else:
                 rval.append(acc)
-                shelvery.logger.info(f"Collected account {acc} to share backups with")
+                shelvery.logger.info(f"Collected account {acc} to collect backups from")
 
         return rval
 


### PR DESCRIPTION
- Populate the BackupResource object with the snapshot's properties so that its information is accessible in the destination account.
- Improve logging.