### PR TITLE
ec2ami: pass in the region to the boto client.

### DIFF
--- a/shelvery/ec2ami_backup.py
+++ b/shelvery/ec2ami_backup.py
@@ -149,7 +149,7 @@ class ShelveryEC2AMIBackup(ShelveryEC2Backup):
                                           )['ImageId']
 
     def get_backup_resource(self, region: str, backup_id: str) -> BackupResource:
-        ec2client = AwsHelper.boto3_client('ec2', arn=self.role_arn, external_id=self.role_external_id)
+        ec2client = AwsHelper.boto3_client('ec2', region_name=region, arn=self.role_arn, external_id=self.role_external_id)
         ami = ec2client.describe_images(ImageIds=[backup_id])['Images'][0]
 
         d_tags = dict(map(lambda x: (x['Key'], x['Value']), ami['Tags']))


### PR DESCRIPTION
After copying an AMI to a different region, shelvery fails to get the status of that AMI because shelvery is looking for the AMI in the same region it has copied it from. This will pass in the copied to region when querying the status