### PR TITLE
Clean up shared Redshift snapshots

### DIFF
--- a/shelvery/aws_helper.py
+++ b/shelvery/aws_helper.py
@@ -32,17 +32,13 @@ class AwsHelper:
                     'Effect': 'Allow',
                     'Principal':{'AWS':f"arn:aws:iam::{shared_account_id}:root"} ,
                     'Action': ['s3:Get*', 's3:List*'],
-                    'Resource': [
-                        f"arn:aws:s3:::{bucket_name}",
-                    ]
+                    'Resource': f"arn:aws:s3:::{bucket_name}"
                 })
                 policy_stmt.append({
                     'Effect': 'Allow',
                     'Principal':{'AWS':f"arn:aws:iam::{shared_account_id}:root"} ,
                     'Action': 's3:*',
-                    'Resource': [
-                        f"arn:aws:s3:::{bucket_name}/{S3_DATA_PREFIX}/shared/{shared_account_id}*",
-                    ]
+                    'Resource': f"arn:aws:s3:::{bucket_name}/{S3_DATA_PREFIX}/shared/{shared_account_id}*"
                 })
         return json.dumps({'Version': '2012-10-17', 'Id': 'shelvery-generated', 'Statement': policy_stmt}, separators=(',', ':'))
 

--- a/shelvery/redshift_backup.py
+++ b/shelvery/redshift_backup.py
@@ -37,8 +37,8 @@ class ShelveryRedshiftBackup(ShelveryEngine):
 		snapshot_id = backup_resource.backup_id.split(":")[-1].split("/")[1]
 
 		response = redshift_client.describe_cluster_snapshots(
-            SnapshotIdentifier=snapshot_id
-        )
+			SnapshotIdentifier=snapshot_id
+		)
 
 		snapshot = next((snap for snap in response['Snapshots'] if snap['SnapshotIdentifier'] == snapshot_id), None)
 


### PR DESCRIPTION
- revoke access to shared Redshift snapshots before deleting them so they can be cleaned up https://github.com/base2Services/shelvery-aws-backups/commit/d0438cd0e60008177f297aa2bca473f18b47c43b
- fix s3 bucket policy comparison https://github.com/base2Services/shelvery-aws-backups/commit/5993b7eb09d1ecd9dac681564761c9705c1c885e