### PR TITLE
Feature/bugfix copysharedbackup

### DIFF
--- a/shelvery/documentdb_backup.py
+++ b/shelvery/documentdb_backup.py
@@ -139,7 +139,7 @@ class ShelveryDocumentDbBackup(ShelveryEngine):
             kms_key = source_backup.resource_properties['KmsKeyId']
             self.logger.info(f"Snapshot {source_backup.backup_id} is encrypted with the kms key {kms_key}")
 
-            copy_kms_key = RuntimeConfig.get_copy_kms_key_id(source_backup.entity_resource.tags, self)
+            copy_kms_key = RuntimeConfig.get_copy_kms_key_id(source_backup.tags, self)
             # if a new key is provided by config encypt the copy with the new kms key
             if copy_kms_key is not None:
                 self.logger.info(
@@ -149,8 +149,8 @@ class ShelveryDocumentDbBackup(ShelveryEngine):
             params['KmsKeyId'] = kms_key
         else:
             # if the backup is not encrypted and the encrypt_copy is enabled, encrypted the backup with the provided kms key
-            if RuntimeConfig.get_encrypt_copy(source_backup.entity_resource.tags, self):
-                kms_key = RuntimeConfig.get_copy_kms_key_id(source_backup.entity_resource.tags, self)
+            if RuntimeConfig.get_encrypt_copy(source_backup.tags, self):
+                kms_key = RuntimeConfig.get_copy_kms_key_id(source_backup.tags, self)
                 if kms_key is not None:
                     self.logger.info(
                         f"Snapshot {source_backup.backup_id} is not encrypted. Encrypting the copy with KMS key {kms_key}")

--- a/shelvery/documentdb_backup.py
+++ b/shelvery/documentdb_backup.py
@@ -139,7 +139,7 @@ class ShelveryDocumentDbBackup(ShelveryEngine):
             kms_key = source_backup.resource_properties['KmsKeyId']
             self.logger.info(f"Snapshot {source_backup.backup_id} is encrypted with the kms key {kms_key}")
 
-            copy_kms_key = RuntimeConfig.get_copy_kms_key_id(backup_resource.entity_resource.tags, self)
+            copy_kms_key = RuntimeConfig.get_copy_kms_key_id(source_backup.entity_resource.tags, self)
             # if a new key is provided by config encypt the copy with the new kms key
             if copy_kms_key is not None:
                 self.logger.info(
@@ -149,8 +149,8 @@ class ShelveryDocumentDbBackup(ShelveryEngine):
             params['KmsKeyId'] = kms_key
         else:
             # if the backup is not encrypted and the encrypt_copy is enabled, encrypted the backup with the provided kms key
-            if RuntimeConfig.get_encrypt_copy(backup_resource.entity_resource.tags, self):
-                kms_key = RuntimeConfig.get_copy_kms_key_id(backup_resource.entity_resource.tags, self)
+            if RuntimeConfig.get_encrypt_copy(source_backup.entity_resource.tags, self):
+                kms_key = RuntimeConfig.get_copy_kms_key_id(source_backup.entity_resource.tags, self)
                 if kms_key is not None:
                     self.logger.info(
                         f"Snapshot {source_backup.backup_id} is not encrypted. Encrypting the copy with KMS key {kms_key}")

--- a/shelvery/rds_cluster_backup.py
+++ b/shelvery/rds_cluster_backup.py
@@ -134,7 +134,7 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
             kms_key = source_backup.resource_properties['KmsKeyId']
             self.logger.info(f"Snapshot {source_backup.backup_id} is encrypted with the kms key {kms_key}")
             
-            copy_kms_key = RuntimeConfig.get_copy_kms_key_id(backup_resource.entity_resource.tags, self)
+            copy_kms_key = RuntimeConfig.get_copy_kms_key_id(source_backup.entity_resource.tags, self)
             # if a new key is provided by config encypt the copy with the new kms key
             if copy_kms_key is not None:
                 self.logger.info(f"Snapshot {source_backup.backup_id} will be copied and encrypted with the kms key {copy_kms_key}")
@@ -143,8 +143,8 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
             params['KmsKeyId'] = kms_key
         else:
             # if the backup is not encrypted and the encrypt_copy is enabled, encrypted the backup with the provided kms key
-            if RuntimeConfig.get_encrypt_copy(backup_resource.entity_resource.tags, self):
-                kms_key = RuntimeConfig.get_copy_kms_key_id(backup_resource.entity_resource.tags, self)
+            if RuntimeConfig.get_encrypt_copy(source_backup.entity_resource.tags, self):
+                kms_key = RuntimeConfig.get_copy_kms_key_id(source_backup.entity_resource.tags, self)
                 if kms_key is not None:
                     self.logger.info(f"Snapshot {source_backup.backup_id} is not encrypted. Encrypting the copy with KMS key {kms_key}")
                     params['KmsKeyId'] = kms_key

--- a/shelvery/rds_cluster_backup.py
+++ b/shelvery/rds_cluster_backup.py
@@ -134,7 +134,7 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
             kms_key = source_backup.resource_properties['KmsKeyId']
             self.logger.info(f"Snapshot {source_backup.backup_id} is encrypted with the kms key {kms_key}")
             
-            copy_kms_key = RuntimeConfig.get_copy_kms_key_id(source_backup.entity_resource.tags, self)
+            copy_kms_key = RuntimeConfig.get_copy_kms_key_id(source_backup.tags, self)
             # if a new key is provided by config encypt the copy with the new kms key
             if copy_kms_key is not None:
                 self.logger.info(f"Snapshot {source_backup.backup_id} will be copied and encrypted with the kms key {copy_kms_key}")
@@ -143,8 +143,8 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
             params['KmsKeyId'] = kms_key
         else:
             # if the backup is not encrypted and the encrypt_copy is enabled, encrypted the backup with the provided kms key
-            if RuntimeConfig.get_encrypt_copy(source_backup.entity_resource.tags, self):
-                kms_key = RuntimeConfig.get_copy_kms_key_id(source_backup.entity_resource.tags, self)
+            if RuntimeConfig.get_encrypt_copy(source_backup.tags, self):
+                kms_key = RuntimeConfig.get_copy_kms_key_id(source_backup.tags, self)
                 if kms_key is not None:
                     self.logger.info(f"Snapshot {source_backup.backup_id} is not encrypted. Encrypting the copy with KMS key {kms_key}")
                     params['KmsKeyId'] = kms_key


### PR DESCRIPTION
Fixed issue with shared backup failing to copy due to reference to 'backup_resource' instead of 'source_backup'

Tested pulling a shared backup with rds_cluster & docdb which both now seem to work as intended.