### PR TITLE
Feature/skip zero retention

### DIFF
--- a/shelvery/backup_resource.py
+++ b/shelvery/backup_resource.py
@@ -159,7 +159,18 @@ class BackupResource:
 
     def entity_resource_tags(self):
         return self.entity_resource.tags if self.entity_resource is not None else {}
-
+    
+    def calculate_retention_type(self):
+        if self.date_created.day == 1:
+            if self.date_created.month == 1:
+                return self.RETENTION_YEARLY
+            else:
+                return  self.RETENTION_MONTHLY
+        elif self.date_created.weekday() == 6:
+            return self.RETENTION_WEEKLY
+        else:
+            return self.RETENTION_DAILY
+    
     def calculate_expire_date(self, engine, custom_retention_types=None):
         """Determine expire date, based on 'retention_type' tag"""
         if self.retention_type == BackupResource.RETENTION_DAILY:

--- a/shelvery/backup_resource.py
+++ b/shelvery/backup_resource.py
@@ -37,8 +37,6 @@ class BackupResource:
         # determine retention period
         # Spoof monthly for testing (#TODO Remove this)
         
-        self.date_created.day = 1
-        self.date_created.month = 2
         if self.date_created.day == 1:
             if self.date_created.month == 1:
                 self.retention_type = self.RETENTION_YEARLY
@@ -48,6 +46,8 @@ class BackupResource:
             self.retention_type = self.RETENTION_WEEKLY
         else:
             self.retention_type = self.RETENTION_DAILY
+            
+        self.retention_type = self.RETENTION_WEEKLY
 
         # determine backup name. Hash of resource id is added to support creating backups
         # with resources having a same name

--- a/shelvery/backup_resource.py
+++ b/shelvery/backup_resource.py
@@ -160,17 +160,6 @@ class BackupResource:
     def entity_resource_tags(self):
         return self.entity_resource.tags if self.entity_resource is not None else {}
     
-    def calculate_retention_type(self):
-        if self.date_created.day == 1:
-            if self.date_created.month == 1:
-                return self.RETENTION_YEARLY
-            else:
-                return  self.RETENTION_MONTHLY
-        elif self.date_created.weekday() == 6:
-            return self.RETENTION_WEEKLY
-        else:
-            return self.RETENTION_DAILY
-    
     def calculate_expire_date(self, engine, custom_retention_types=None):
         """Determine expire date, based on 'retention_type' tag"""
         if self.retention_type == BackupResource.RETENTION_DAILY:

--- a/shelvery/backup_resource.py
+++ b/shelvery/backup_resource.py
@@ -35,8 +35,6 @@ class BackupResource:
         self.account_id = AwsHelper.local_account_id()
 
         # determine retention period
-        # Spoof monthly for testing (#TODO Remove this)
-        
         if self.date_created.day == 1:
             if self.date_created.month == 1:
                 self.retention_type = self.RETENTION_YEARLY
@@ -46,8 +44,6 @@ class BackupResource:
             self.retention_type = self.RETENTION_WEEKLY
         else:
             self.retention_type = self.RETENTION_DAILY
-            
-        self.retention_type = self.RETENTION_WEEKLY
 
         # determine backup name. Hash of resource id is added to support creating backups
         # with resources having a same name
@@ -201,11 +197,12 @@ class BackupResource:
         self.__region = region
 
     def set_retention_type(self, retention_type: str):
+        self.retention_type = retention_type
         self.name = '-'.join(self.name.split('-')[0:-1]) + f"-{retention_type}"
         self.tags[f"{self.tags['shelvery:tag_name']}:name"] = self.name
         self.tags['Name'] = self.name
         self.tags[f"{self.tags['shelvery:tag_name']}:retention_type"] = retention_type
-
+    
     @property
     def boto3_tags(self):
         tags = self.tags

--- a/shelvery/backup_resource.py
+++ b/shelvery/backup_resource.py
@@ -35,6 +35,10 @@ class BackupResource:
         self.account_id = AwsHelper.local_account_id()
 
         # determine retention period
+        # Spoof monthly for testing (#TODO Remove this)
+        
+        self.date_created.day = 1
+        self.date_created.month = 2
         if self.date_created.day == 1:
             if self.date_created.month == 1:
                 self.retention_type = self.RETENTION_YEARLY

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -34,11 +34,6 @@ class ShelveryEngine:
     DEFAULT_KEEP_WEEKLY = 8
     DEFAULT_KEEP_MONTHLY = 12
     DEFAULT_KEEP_YEARLY = 10
-    
-    CREATE_DAILY = RuntimeConfig.get_keep_daily != 0
-    CREATE_WEEKLY = RuntimeConfig.get_keep_weekly != 0
-    CREATE_MONTHLY = RuntimeConfig.get_keep_monthly != 0
-    CREATE_YEARLY = RuntimeConfig.get_keep_yearly != 0
 
     BACKUP_RESOURCE_TAG = 'create_backup'
 
@@ -215,24 +210,30 @@ class ShelveryEngine:
             # get retention type of backup resource
             retention_value = backup_resource.retention_type
             self.logger.info("Ret Type: " + str(retention_value))
+            self.logger.info("Create Daily: " + str(RuntimeConfig.get_keep_daily(backup_resource.entity_resource_tags(),self)))
             
+            CREATE_DAILY = RuntimeConfig.get_keep_daily(backup_resource.entity_resource_tags(),self) != 0
+            CREATE_WEEKLY = RuntimeConfig.get_keep_weekly() != 0
+            CREATE_MONTHLY = RuntimeConfig.get_keep_monthly() != 0
+            CREATE_YEARLY = RuntimeConfig.get_keep_yearly() != 0
+                    
             # check whether we should create a backup for this retention type
             if retention_value == backup_resource.RETENTION_DAILY:
-                if not self.CREATE_DAILY:
+                if not CREATE_DAILY:
                     self.logger.info(f"Skipping {backup_resource.RETENTION_DAILY} backup as specified in configuration ")
                     continue
-            if retention_value == backup_resource.RETENTION_WEEKLY:
-                if not self.CREATE_WEEKLY:
-                    self.logger.info(f"Skipping {backup_resource.RETENTION_WEEKLY} backup as specified in configuration ")
-                    continue
-            if retention_value == backup_resource.RETENTION_MONTHLY:
-                if not self.CREATE_MONTHLY:
-                    self.logger.info(f"Skipping {backup_resource.RETENTION_MONTHLY} backup as specified in configuration ")
-                    continue
-            if retention_value == backup_resource.RETENTION_YEARLY:
-                if not self.CREATE_YEARLY:
-                    self.logger.info(f"Skipping {backup_resource.RETENTION_YEARLY} backup as specified in configuration ")
-                    continue
+            # if retention_value == backup_resource.RETENTION_WEEKLY:
+            #     if not self.CREATE_WEEKLY:
+            #         self.logger.info(f"Skipping {backup_resource.RETENTION_WEEKLY} backup as specified in configuration ")
+            #         continue
+            # if retention_value == backup_resource.RETENTION_MONTHLY:
+            #     if not self.CREATE_MONTHLY:
+            #         self.logger.info(f"Skipping {backup_resource.RETENTION_MONTHLY} backup as specified in configuration ")
+            #         continue
+            # if retention_value == backup_resource.RETENTION_YEARLY:
+            #     if not self.CREATE_YEARLY:
+            #         self.logger.info(f"Skipping {backup_resource.RETENTION_YEARLY} backup as specified in configuration ")
+            #         continue
             
             # if retention is explicitly given by runtime environment
             if current_retention_type is not None:

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -187,8 +187,6 @@ class ShelveryEngine:
             backup_resource.RETENTION_MONTHLY : CREATE_MONTHLY,
             backup_resource.RETENTION_YEARLY : CREATE_YEARLY,
         }
-        self.logger.info("Retention:" + str(retention))
-        self.logger.info(f"Retention Type: {retention_value} with value {retention[retention_value]}")
         
         return True if retention[retention_value] else False              
 
@@ -235,8 +233,6 @@ class ShelveryEngine:
             # if retention is explicitly given by runtime environment
             if current_retention_type is not None:
                 backup_resource.set_retention_type(current_retention_type)
-                
-            self.logger.info("retention type: " + str(current_retention_type))
 
             dr_regions = RuntimeConfig.get_dr_regions(backup_resource.entity_resource.tags, self)
             backup_resource.tags[f"{RuntimeConfig.get_tag_prefix()}:dr_regions"] = ','.join(dr_regions)

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -210,15 +210,16 @@ class ShelveryEngine:
         backup_resources = []
         current_retention_type = RuntimeConfig.get_current_retention_type(self)
         for r in resources:
-            retention_value = r.calculate_retention_type()
-            self.logger.info("Ret Type: " + str(retention_value))
-            
             backup_resource = BackupResource(
                 tag_prefix=RuntimeConfig.get_tag_prefix(),
                 entity_resource=r,
                 copy_resource_tags=RuntimeConfig.copy_resource_tags(self),
                 exluded_resource_tag_keys=RuntimeConfig.get_exluded_resource_tag_keys(self)
             )
+            
+            retention_value = backup_resource.calculate_retention_type()
+            self.logger.info("Ret Type: " + str(retention_value))
+            
             # if retention is explicitly given by runtime environment
             if current_retention_type is not None:
                 backup_resource.set_retention_type(current_retention_type)

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -66,7 +66,7 @@ class ShelveryEngine:
     def set_lambda_environment(self, payload, context):
         self.lambda_payload   = payload
         self.lambda_context   = context
-        self.aws_request_id   = context. aws_request_id
+        self.aws_request_id   = context.aws_request_id
         self.role_arn         = RuntimeConfig.get_role_arn(self)
         self.role_external_id = RuntimeConfig.get_role_external_id(self)
         if ('arguments' in payload) and (LAMBDA_WAIT_ITERATION in payload['arguments']):

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -210,30 +210,34 @@ class ShelveryEngine:
             # get retention type of backup resource
             retention_value = backup_resource.retention_type
             self.logger.info("Ret Type: " + str(retention_value))
-            self.logger.info("Create Daily: " + str(RuntimeConfig.get_keep_daily(backup_resource.entity_resource_tags(),self)))
             
             CREATE_DAILY = RuntimeConfig.get_keep_daily(backup_resource.entity_resource_tags(),self) != 0
-            CREATE_WEEKLY = RuntimeConfig.get_keep_weekly() != 0
-            CREATE_MONTHLY = RuntimeConfig.get_keep_monthly() != 0
-            CREATE_YEARLY = RuntimeConfig.get_keep_yearly() != 0
+            CREATE_WEEKLY = RuntimeConfig.get_keep_weekly(backup_resource.entity_resource_tags(),self) != 0
+            CREATE_MONTHLY= RuntimeConfig.get_keep_monthly(backup_resource.entity_resource_tags(),self) != 0
+            CREATE_YEARLY = RuntimeConfig.get_keep_yearly(backup_resource.entity_resource_tags(),self) != 0
+            
+            self.logger.info("Create Daily: " + str(CREATE_DAILY))
+            self.logger.info("Create Weekly: " + str(CREATE_WEEKLY))
+            self.logger.info("Create Monthly: " + str(CREATE_MONTHLY))
+            self.logger.info("Create Yearly: " + str(CREATE_YEARLY))
                     
             # check whether we should create a backup for this retention type
             if retention_value == backup_resource.RETENTION_DAILY:
                 if not CREATE_DAILY:
                     self.logger.info(f"Skipping {backup_resource.RETENTION_DAILY} backup as specified in configuration ")
                     continue
-            # if retention_value == backup_resource.RETENTION_WEEKLY:
-            #     if not self.CREATE_WEEKLY:
-            #         self.logger.info(f"Skipping {backup_resource.RETENTION_WEEKLY} backup as specified in configuration ")
-            #         continue
-            # if retention_value == backup_resource.RETENTION_MONTHLY:
-            #     if not self.CREATE_MONTHLY:
-            #         self.logger.info(f"Skipping {backup_resource.RETENTION_MONTHLY} backup as specified in configuration ")
-            #         continue
-            # if retention_value == backup_resource.RETENTION_YEARLY:
-            #     if not self.CREATE_YEARLY:
-            #         self.logger.info(f"Skipping {backup_resource.RETENTION_YEARLY} backup as specified in configuration ")
-            #         continue
+            if retention_value == backup_resource.RETENTION_WEEKLY:
+                if not CREATE_WEEKLY:
+                    self.logger.info(f"Skipping {backup_resource.RETENTION_WEEKLY} backup as specified in configuration ")
+                    continue
+            if retention_value == backup_resource.RETENTION_MONTHLY:
+                if not CREATE_MONTHLY:
+                    self.logger.info(f"Skipping {backup_resource.RETENTION_MONTHLY} backup as specified in configuration ")
+                    continue
+            if retention_value == backup_resource.RETENTION_YEARLY:
+                if not CREATE_YEARLY:
+                    self.logger.info(f"Skipping {backup_resource.RETENTION_YEARLY} backup as specified in configuration ")
+                    continue
             
             # if retention is explicitly given by runtime environment
             if current_retention_type is not None:

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -183,6 +183,10 @@ class ShelveryEngine:
         self.logger.info(f"Collecting entities of type {resource_type} tagged with "
                          f"{RuntimeConfig.get_tag_prefix()}:{self.BACKUP_RESOURCE_TAG}")
         resources = self.get_entities_to_backup(f"{RuntimeConfig.get_tag_prefix()}:{self.BACKUP_RESOURCE_TAG}")
+        
+        for res in resources:
+            print("Tags:" + str(res.resource_id))
+            print("Tags:" + str(res.tags))
 
         # allows user to select single entity to be backed up
         if RuntimeConfig.get_shelvery_select_entity(self) is not None:
@@ -195,8 +199,6 @@ class ShelveryEngine:
             )
 
         self.logger.info(f"{len(resources)} resources of type {resource_type} collected for backup")
-        
-        self.logger.info("resources: " + str(resources))
 
         # create and collect backups
         backup_resources = []

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -219,7 +219,6 @@ class ShelveryEngine:
         # create and collect backups
         backup_resources = []
         current_retention_type = RuntimeConfig.get_current_retention_type(self)
-        self.logger.info(f"Current Retention Type: {current_retention_type}")
         for r in resources:
             backup_resource = BackupResource(
                 tag_prefix=RuntimeConfig.get_tag_prefix(),

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -195,6 +195,8 @@ class ShelveryEngine:
             )
 
         self.logger.info(f"{len(resources)} resources of type {resource_type} collected for backup")
+        
+        self.logger.info("resources: " + str(resources))
 
         # create and collect backups
         backup_resources = []
@@ -209,6 +211,8 @@ class ShelveryEngine:
             # if retention is explicitly given by runtime environment
             if current_retention_type is not None:
                 backup_resource.set_retention_type(current_retention_type)
+                
+            self.logger.info("retention type: " + str(current_retention_type))
 
             dr_regions = RuntimeConfig.get_dr_regions(backup_resource.entity_resource.tags, self)
             backup_resource.tags[f"{RuntimeConfig.get_tag_prefix()}:dr_regions"] = ','.join(dr_regions)

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -34,6 +34,10 @@ class ShelveryEngine:
     DEFAULT_KEEP_WEEKLY = 8
     DEFAULT_KEEP_MONTHLY = 12
     DEFAULT_KEEP_YEARLY = 10
+    CREATE_DAILY = True
+    CREATE_WEEKLY = True
+    CREATE_MONTHLY = True
+    CREATE_YEARLY = True
 
     BACKUP_RESOURCE_TAG = 'create_backup'
 
@@ -206,6 +210,9 @@ class ShelveryEngine:
         backup_resources = []
         current_retention_type = RuntimeConfig.get_current_retention_type(self)
         for r in resources:
+            retention_value = r.calculate_retention_type()
+            self.logger.info("Ret Type: " + str(retention_value))
+            
             backup_resource = BackupResource(
                 tag_prefix=RuntimeConfig.get_tag_prefix(),
                 entity_resource=r,

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -187,6 +187,8 @@ class ShelveryEngine:
         for res in resources:
             print("Tags:" + str(res.resource_id))
             print("Tags:" + str(res.tags))
+            print("Payload:" + str(self.lambda_payload))
+            print("Context:" + str(self.lambda_context))
 
         # allows user to select single entity to be backed up
         if RuntimeConfig.get_shelvery_select_entity(self) is not None:

--- a/template.yaml
+++ b/template.yaml
@@ -7,7 +7,7 @@ Parameters:
     Default: "0 0 ? * * *"
   CreateBackupSchedule:
     Type: String
-    Default: "0 1 ? * * *"
+    Default: "*/10 * ? * * *"
   CleanBackupsSchedule:
     Type: String
     Default: "0 2 ? * * *"

--- a/template.yaml
+++ b/template.yaml
@@ -7,7 +7,7 @@ Parameters:
     Default: "0 0 ? * * *"
   CreateBackupSchedule:
     Type: String
-    Default: "*/10 * ? * * *"
+    Default: "0 1 ? * * *"
   CleanBackupsSchedule:
     Type: String
     Default: "0 2 ? * * *"


### PR DESCRIPTION
Added feature to skip creating backups for those with retention types (daily,weekly,monthly,yearly) that are set to 0 in the configuration variables.

### Workflow

1) We call the function 'verify_retention' to that verifies the retention type for the current backup resource (Based on date of creation) against the specifed value in the config
```
if not self._verify_retention(backup_resource=backup_resource):
```

2) We check whether the retention value is set to '0' in the config
``` 
CREATE_DAILY = RuntimeConfig.get_keep_daily(backup_resource.entity_resource_tags(),self) != 0
```

3) A dict of all retention types and their corresponding boolean on whether we should create them or not is created.
```
retention = {
            backup_resource.RETENTION_DAILY : CREATE_DAILY,
            backup_resource.RETENTION_WEEKLY : CREATE_WEEKLY,
            backup_resource.RETENTION_MONTHLY : CREATE_MONTHLY,
            backup_resource.RETENTION_YEARLY : CREATE_YEARLY,
        }
```

4) We then return True/False depending on if the supplied retention value is True/False in the dictionary
```
return True if retention[retention_value] else False 
```
5) Lastly in the engine, we call this function and skip any iterations where the retention type is set to '0'
```
if not self._verify_retention(backup_resource=backup_resource):
                self.logger.info(f"Skipping backup as retention type {backup_resource.retention_type} is disabled")
                continue
```

### EC2AMI 'Daily'Example

1) The current date is 31-Aug-2022, as such we expect that the retention type for the created backup will be 'daily'

2) For a given ec2 instance, we can observe the following specified config defines that the 'daily' retention is set to 0. 
<img width="572" alt="Screen Shot 2022-08-31 at 11 00 34 am" src="https://user-images.githubusercontent.com/64295670/187569988-bf19f0df-e667-4951-90f8-be4ad9928c9e.png">

3) We call 'shelvery ec2ami create_backups' and can observe the creation of the backup is skipped.
<img width="872" alt="Screen Shot 2022-08-31 at 11 01 59 am" src="https://user-images.githubusercontent.com/64295670/187570115-a9962076-4297-4948-bf24-4ccba6ba2364.png">

4) Lastly, if we change the value from '0' to '1' in the config then call 'shelvery ec2ami create_backups'  again we observe that the backup is created as expected.
<img width="872" alt="Screen Shot 2022-08-31 at 11 03 29 am" src="https://user-images.githubusercontent.com/64295670/187570289-f375031b-c38a-4782-b957-8fd6bf56ace7.png">
