### PR TITLE
Feature/snapshot reencryption

### DIFF
--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -684,7 +684,7 @@ class ShelveryEngine:
                 new_resource_id = self.copy_backup_to_region(backup_id, backup_region)
                 new_backup_resource = self.get_backup_resource(backup_region, new_resource_id)
                 backup_resource = new_backup_resource
-                self.logger.info(f"Created new backup {backup_resource}")
+                self.logger.info(f"Created new encrypted backup {backup_resource.backup_id}")
                 # wait till new snapshot is available
                 if not self.wait_backup_available(backup_region=backup_region,
                                               backup_id=backup_resource.backup_id,

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -675,7 +675,9 @@ class ShelveryEngine:
 
         self.logger.info(f"Do share backup {backup_id} ({backup_region}) with {destination_account_id}")
         try:
-            self.share_backup_with_account(backup_region, backup_id, destination_account_id)
+            new_backup_id = self.share_backup_with_account(backup_region, backup_id, destination_account_id)
+            #assign new backup id if new snapshot is created (eg: re-encrypted rds snapshot)
+            backup_id = new_backup_id if new_backup_id else backup_id
             backup_resource = self.get_backup_resource(backup_region, backup_id)
             self._write_backup_data(
                 backup_resource,

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -678,6 +678,7 @@ class ShelveryEngine:
             new_backup_id = self.share_backup_with_account(backup_region, backup_id, destination_account_id)
             #assign new backup id if new snapshot is created (eg: re-encrypted rds snapshot)
             backup_id = new_backup_id if new_backup_id else backup_id
+            self.logger.info(f"Shared backup {backup_id} ({backup_region}) with {destination_account_id}")
             backup_resource = self.get_backup_resource(backup_region, backup_id)
             self._write_backup_data(
                 backup_resource,

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -688,7 +688,7 @@ class ShelveryEngine:
             else:
                 self.logger.info(f"No re-encrypt key detected")
 
-            self.share_backup_with_account(backup_region, backup_id, destination_account_id)
+            self.share_backup_with_account(backup_region, backup_resource.backup_id, destination_account_id)
             
             self._write_backup_data(
                 backup_resource,
@@ -705,12 +705,12 @@ class ShelveryEngine:
         except ClientError as e:
             if e.response['Error']['Code'] == 'InvalidDBSnapshotState':
                 # This will occasionally happen due to AWS eventual consistency model
-                self.logger.warn(f"Retrying to share backup {backup_id} ({backup_region}) with account {destination_account_id} due to exception InvalidDBSnapshotState")
+                self.logger.warn(f"Retrying to share backup {backup_resource.backup_id} ({backup_region}) with account {destination_account_id} due to exception InvalidDBSnapshotState")
                 self.share_backup(backup_resource, destination_account_id)
 
             elif e.response['Error']['Code'] == 'InvalidParameterValue':
                 # Some backups may fail to be shared due to AWS limitations
-                self.logger.warn(f"Attempt to share backup '{backup_id}' in ({backup_region}) with account {destination_account_id} failed: {str(e)}")
+                self.logger.warn(f"Attempt to share backup '{backup_resource.backup_id}' in ({backup_region}) with account {destination_account_id} failed: {str(e)}")
             else:
                 self.snspublisher_error.notify({
                     'Operation': 'ShareBackup',
@@ -721,7 +721,7 @@ class ShelveryEngine:
                     'DestinationAccount': kwargs['AwsAccountId']
                 })
                 self.logger.exception(
-                    f"Failed to share backup {backup_id} ({backup_region}) with account {destination_account_id}")
+                    f"Failed to share backup {backup_resource.backup_id} ({backup_region}) with account {destination_account_id}")
 
     def store_backup_data(self, backup_resource: BackupResource):
         """

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -685,6 +685,12 @@ class ShelveryEngine:
                 new_backup_resource = self.get_backup_resource(backup_region, new_resource_id)
                 backup_resource = new_backup_resource
                 self.logger.info(f"Created new backup {backup_resource}")
+                # wait till new snapshot is available
+                if not self.wait_backup_available(backup_region=backup_region,
+                                              backup_id=backup_resource.backup_id,
+                                              lambda_method='do_share_backup',
+                                              lambda_args=kwargs):
+                    return
             else:
                 self.logger.info(f"No re-encrypt key detected")
 

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -680,10 +680,14 @@ class ShelveryEngine:
             reencrypt_kms_key = RuntimeConfig.get_reencrypt_kms_key_id(backup_resource.tags, self)
             # if a re-encrypt key is provided, create a new re-encrypted snapshot before sharing
             if reencrypt_kms_key is not None:
+                self.logger.info(f"Re-encrypt KMS Key found, creating new backup with {reencrypt_kms_key}")
                 new_resource_id = self.copy_backup_to_region(backup_id, backup_region)
                 new_backup_resource = self.get_backup_resource(backup_region, new_resource_id)
                 backup_resource = new_backup_resource
-            
+                self.logger.info(f"Created new backup {backup_resource}")
+            else:
+                self.logger.info(f"No re-encrypt key detected")
+
             self.share_backup_with_account(backup_region, backup_id, destination_account_id)
             
             self._write_backup_data(

--- a/shelvery/rds_backup.py
+++ b/shelvery/rds_backup.py
@@ -100,24 +100,24 @@ class ShelveryRDSBackup(ShelveryEngine):
         
         # if a re-encrypt key is provided, create new re-encrypted snapshot and share that instead
         if kms_key:
-            self.logger.info(f"Re-encrypt KMS Key found, creating new encrypted backup with supplied re-encrypt key")
+            self.logger.info(f"Re-encrypt KMS Key found, creating new backup with {kms_key}")
             # create re-encrypted backup
-            new_backup_id = self.copy_backup_to_region(backup_id, backup_region)
-            self.logger.info(f"Creating new encrypted backup {new_backup_id}")
+            backup_id = self.copy_backup_to_region(backup_id, backup_region)
+            self.logger.info(f"Creating new encrypted backup {backup_id}")
             # wait till new snapshot is available
             if not self.wait_backup_available(backup_region=backup_region,
-                backup_id=new_backup_id,
+                backup_id=backup_id,
                 lambda_method='do_share_backup',
                 lambda_args={}):
                 return
-            self.logger.info(f"New encrypted backup {new_backup_id} created")
+            self.logger.info(f"New encrypted backup {backup_id} created")
             created_new_encrypted_snapshot = True
         else:
             self.logger.info(f"No re-encrypt key detected")
             created_new_encrypted_snapshot = False 
         
         rds_client.modify_db_snapshot_attribute(
-            DBSnapshotIdentifier=new_backup_id,
+            DBSnapshotIdentifier=backup_id,
             AttributeName='restore',
             ValuesToAdd=[aws_account_id]
         )
@@ -126,12 +126,7 @@ class ShelveryRDSBackup(ShelveryEngine):
             # delete old snapshot
             self.delete_backup(backup_resource)
             
-            # re-name snapshot to old name
-            rds_client.modify_db_snapshot_attribute(
-                DBSnapshotIdentifier=new_backup_id,
-                AttributeName='dbSnapshotIdentifier',
-                ValuesToAdd=[aws_account_id]
-            )
+        return backup_id
 
     def copy_backup_to_region(self, backup_id: str, region: str) -> str:
         local_region = boto3.session.Session().region_name

--- a/shelvery/rds_backup.py
+++ b/shelvery/rds_backup.py
@@ -95,11 +95,36 @@ class ShelveryRDSBackup(ShelveryEngine):
 
     def share_backup_with_account(self, backup_region: str, backup_id: str, aws_account_id: str):
         rds_client = AwsHelper.boto3_client('rds', region_name=backup_region, arn=self.role_arn, external_id=self.role_external_id)
+        backup_resource = self.get_backup_resource(backup_region, backup_id)
+        kms_key = RuntimeConfig.get_reencrypt_kms_key_id(backup_resource.tags, self)
+        
+        # if a re-encrypt key is provided, create new re-encrypted snapshot and share that instead
+        if kms_key:
+            self.logger.info(f"Re-encrypt KMS Key found, creating new backup with {kms_key}")
+            # create re-encrypted backup
+            backup_id = self.copy_backup_to_region(backup_id, backup_region)
+            self.logger.info(f"Creating new encrypted backup {backup_id}")
+            # wait till new snapshot is available
+            if not self.wait_backup_available(backup_region=backup_region,
+                backup_id=backup_id,
+                lambda_method='do_share_backup',
+                lambda_args={}):
+                return
+            self.logger.info(f"New encrypted backup {backup_id} created")
+            created_new_encrypted_snapshot = True
+        else:
+            self.logger.info(f"No re-encrypt key detected")
+            created_new_encrypted_snapshot = False 
+        
         rds_client.modify_db_snapshot_attribute(
             DBSnapshotIdentifier=backup_id,
             AttributeName='restore',
             ValuesToAdd=[aws_account_id]
         )
+        # if re-encryption occured, clean up old snapshot
+        if created_new_encrypted_snapshot:
+            # delete old snapshot
+            self.delete_backup(backup_resource)
 
     def copy_backup_to_region(self, backup_id: str, region: str) -> str:
         local_region = boto3.session.Session().region_name
@@ -116,7 +141,7 @@ class ShelveryRDSBackup(ShelveryEngine):
             # tags are created explicitly
             'CopyTags': False
         }
-         # add kms key to params if reencrypt key is defined and rename backup
+         # add kms key params if reencrypt key is defined
         if kms_key is not None:
             backup_id = f'{backup_id}-re-encrypted'
             rds_client_params['KmsKeyId'] = kms_key

--- a/shelvery/rds_backup.py
+++ b/shelvery/rds_backup.py
@@ -125,7 +125,8 @@ class ShelveryRDSBackup(ShelveryEngine):
         if created_new_encrypted_snapshot:
             # delete old snapshot
             self.delete_backup(backup_resource)
-            
+            self.logger.info(f"Cleaning up un-encrypted backup: {backup_resource.backup_id}")
+
         return backup_id
 
     def copy_backup_to_region(self, backup_id: str, region: str) -> str:

--- a/shelvery/rds_cluster_backup.py
+++ b/shelvery/rds_cluster_backup.py
@@ -126,7 +126,8 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
         if created_new_encrypted_snapshot:
             # delete old snapshot
             self.delete_backup(backup_resource)
-            
+            self.logger.info(f"Cleaning up un-encrypted backup: {backup_resource.backup_id}")
+        
         return backup_id
 
     def copy_backup_to_region(self, backup_id: str, region: str) -> str:

--- a/shelvery/rds_cluster_backup.py
+++ b/shelvery/rds_cluster_backup.py
@@ -118,6 +118,7 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
             snapshot_arn = snapshots['DBClusterSnapshots'][0]['DBClusterSnapshotArn']
            
             #Update tags with '-re-encrypted' suffix
+            self.logger.info(f"Updating tags for new snapshot - {backup_id}")
             tags = self.get_backup_resource(backup_region, backup_id).tags
             tags.update({'Name': backup_id, 'shelvery:name': backup_id})
             tag_list = [{'Key': key, 'Value': value} for key, value in tags.items()]

--- a/shelvery/rds_cluster_backup.py
+++ b/shelvery/rds_cluster_backup.py
@@ -110,7 +110,7 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
         snapshot = snapshots['DBClusterSnapshots'][0]
         backup_resource = self.get_backup_resource(local_region, backup_id)
         kms_key = RuntimeConfig.get_reencrypt_kms_key_id(backup_resource.tags, self)
-        # add kms key to params if reencrypt key is defined
+        # add kms key to params if reencrypt key is defined and rename backup
         rds_client_params = {
             'SourceDBClusterSnapshotIdentifier': snapshot['DBClusterSnapshotArn'],
             'TargetDBClusterSnapshotIdentifier': backup_id,
@@ -118,8 +118,10 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
             'CopyTags': False
         }
         if kms_key is not None:
+            backup_id = f'{backup_id}-re-encrypted'
             rds_client_params['KmsKeyId'] = kms_key
-        
+            rds_client_params['TargetDBClusterSnapshotIdentifier'] = backup_id
+                
         rds_client.copy_db_cluster_snapshot(**rds_client_params)
         return backup_id
 

--- a/shelvery/rds_cluster_backup.py
+++ b/shelvery/rds_cluster_backup.py
@@ -171,7 +171,9 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
             rds_client_params['CopyTags'] = True
         
         #Overwrite any params as needed
-        rds_client_params.update(kwargs)               
+        rds_client_params.update(kwargs)          
+        
+        self.logger.info(rds_client_params)     
                 
         rds_client.copy_db_cluster_snapshot(**rds_client_params)
         return backup_id    

--- a/shelvery/rds_cluster_backup.py
+++ b/shelvery/rds_cluster_backup.py
@@ -108,10 +108,13 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
         rds_client = AwsHelper.boto3_client('rds', region_name=region)
         snapshots = client_local.describe_db_cluster_snapshots(DBClusterSnapshotIdentifier=backup_id)
         snapshot = snapshots['DBClusterSnapshots'][0]
+        backup_resource = self.get_backup_resource(local_region, backup_id)
+        kms_key = RuntimeConfig.get_copy_kms_key_id(backup_resource.tags, self)
         rds_client.copy_db_cluster_snapshot(
             SourceDBClusterSnapshotIdentifier=snapshot['DBClusterSnapshotArn'],
             TargetDBClusterSnapshotIdentifier=backup_id,
             SourceRegion=local_region,
+            KmsKeyId=kms_key,
             # tags are created explicitly
             CopyTags=False
         )

--- a/shelvery/rds_cluster_backup.py
+++ b/shelvery/rds_cluster_backup.py
@@ -101,26 +101,24 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
         
         # if a re-encrypt key is provided, create new re-encrypted snapshot and share that instead
         if kms_key:
-            self.logger.info(f"Re-encrypt KMS Key found, creating new encrypted backup with supplied re-encrypt key")
-            # create re-encrypted backup            
-            encrypted_backup_params = {'TargetDBClusterSnapshotIdentifier': backup_id+"-re-encrypted"}
-            new_backup_id = self.create_encrypted_backup(backup_id, backup_region)
-            new_backup_resource = self.get_backup_resource(backup_region, new_backup_id)
-            self.logger.info(f"Creating new encrypted backup {new_backup_id}")
+            self.logger.info(f"Re-encrypt KMS Key found, creating new backup with {kms_key}")
+            # create re-encrypted backup
+            backup_id = self.copy_backup_to_region(backup_id, backup_region)
+            self.logger.info(f"Creating new encrypted backup {backup_id}")
             # wait till new snapshot is available
             if not self.wait_backup_available(backup_region=backup_region,
-                backup_id=new_backup_id,
+                backup_id=backup_id,
                 lambda_method='do_share_backup',
                 lambda_args={}):
                 return
-            self.logger.info(f"New encrypted backup {new_backup_id} created")
+            self.logger.info(f"New encrypted backup {backup_id} created")
             created_new_encrypted_snapshot = True
         else:
             self.logger.info(f"No re-encrypt key detected")
             created_new_encrypted_snapshot = False 
             
         rds_client.modify_db_cluster_snapshot_attribute(
-            DBClusterSnapshotIdentifier=new_backup_id,
+            DBClusterSnapshotIdentifier=backup_id,
             AttributeName='restore',
             ValuesToAdd=[aws_account_id]
         )
@@ -129,29 +127,9 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
             # delete old snapshot
             self.delete_backup(backup_resource)
             
-            # create new snapshot to with original name
-            encrypted_backup_params = {'TargetDBClusterSnapshotIdentifier': backup_id}
-            self.create_encrypted_backup(backup_id, backup_region, encrypted_backup_params)
-        
-            # delete previous snapshot
-            self.delete_backup(new_backup_resource)
-    
-    def copy_backup_to_region(self, backup_id: str, region: str) -> str:
-        local_region = boto3.session.Session().region_name
-        client_local = AwsHelper.boto3_client('rds', arn=self.role_arn, external_id=self.role_external_id)
-        rds_client = AwsHelper.boto3_client('rds', region_name=region)
-        snapshots = client_local.describe_db_cluster_snapshots(DBClusterSnapshotIdentifier=backup_id)
-        snapshot = snapshots['DBClusterSnapshots'][0]
-        rds_client.copy_db_cluster_snapshot(
-            SourceDBClusterSnapshotIdentifier=snapshot['DBClusterSnapshotArn'],
-            TargetDBClusterSnapshotIdentifier=backup_id,
-            SourceRegion=local_region,
-            # tags are created explicitly
-            CopyTags=False
-        )
         return backup_id
-    
-    def create_encrypted_backup(self, backup_id: str, region: str, **kwargs) -> str:
+
+    def copy_backup_to_region(self, backup_id: str, region: str) -> str:
         local_region = boto3.session.Session().region_name
         client_local = AwsHelper.boto3_client('rds', arn=self.role_arn, external_id=self.role_external_id)
         rds_client = AwsHelper.boto3_client('rds', region_name=region)
@@ -167,16 +145,13 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
         }
         # add kms key params if re-encrypt key is defined
         if kms_key is not None:
+            backup_id = f'{backup_id}-re-encrypted'
             rds_client_params['KmsKeyId'] = kms_key
             rds_client_params['CopyTags'] = True
-        
-        #Overwrite any params as needed
-        rds_client_params.update(kwargs)          
-        
-        self.logger.info(rds_client_params)     
-                
+            rds_client_params['TargetDBClusterSnapshotIdentifier'] = backup_id
+                       
         rds_client.copy_db_cluster_snapshot(**rds_client_params)
-        return backup_id    
+        return backup_id
 
     def copy_shared_backup(self, source_account: str, source_backup: BackupResource):
         rds_client = AwsHelper.boto3_client('rds', arn=self.role_arn, external_id=self.role_external_id)

--- a/shelvery/rds_cluster_backup.py
+++ b/shelvery/rds_cluster_backup.py
@@ -96,30 +96,36 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
 
     def share_backup_with_account(self, backup_region: str, backup_id: str, aws_account_id: str):
         rds_client = AwsHelper.boto3_client('rds', region_name=backup_region, arn=self.role_arn, external_id=self.role_external_id)
-        
         backup_resource = self.get_backup_resource(backup_region, backup_id)
         kms_key = RuntimeConfig.get_reencrypt_kms_key_id(backup_resource.tags, self)
         
         # if a re-encrypt key is provided, create new re-encrypted snapshot and share that instead
         if kms_key:
             self.logger.info(f"Re-encrypt KMS Key found, creating new backup with {kms_key}")
-        
+            # create re-encrypted backup
             backup_id = self.copy_backup_to_region(backup_id, backup_region)
-            self.logger.info(f"Created new encrypted backup {backup_id}")
+            self.logger.info(f"Creating new encrypted backup {backup_id}")
             # wait till new snapshot is available
             if not self.wait_backup_available(backup_region=backup_region,
                 backup_id=backup_id,
                 lambda_method='do_share_backup',
                 lambda_args={}):
                 return
+            self.logger.info(f"New encrypted backup {backup_id} created")
+            created_new_encrypted_snapshot = True
         else:
             self.logger.info(f"No re-encrypt key detected")
-
+            created_new_encrypted_snapshot = False 
+            
         rds_client.modify_db_cluster_snapshot_attribute(
             DBClusterSnapshotIdentifier=backup_id,
             AttributeName='restore',
             ValuesToAdd=[aws_account_id]
         )
+        # if re-encryption occured, clean up old snapshot
+        if created_new_encrypted_snapshot:
+            # delete old snapshot
+            self.delete_backup(backup_resource)
 
     def copy_backup_to_region(self, backup_id: str, region: str) -> str:
         local_region = boto3.session.Session().region_name
@@ -135,7 +141,7 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
             'SourceRegion': local_region,
             'CopyTags': False
         }
-        # add kms key to params if re-encrypt key is defined
+        # add kms key params if re-encrypt key is defined
         if kms_key is not None:
             backup_id = f'{backup_id}-re-encrypted'
             rds_client_params['KmsKeyId'] = kms_key

--- a/shelvery/rds_cluster_backup.py
+++ b/shelvery/rds_cluster_backup.py
@@ -101,24 +101,24 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
         
         # if a re-encrypt key is provided, create new re-encrypted snapshot and share that instead
         if kms_key:
-            self.logger.info(f"Re-encrypt KMS Key found, creating new backup with {kms_key}")
+            self.logger.info(f"Re-encrypt KMS Key found, creating new encrypted backup with supplied re-encrypt key")
             # create re-encrypted backup
-            backup_id = self.copy_backup_to_region(backup_id, backup_region)
-            self.logger.info(f"Creating new encrypted backup {backup_id}")
+            new_backup_id = self.copy_backup_to_region(backup_id, backup_region)
+            self.logger.info(f"Creating new encrypted backup {new_backup_id}")
             # wait till new snapshot is available
             if not self.wait_backup_available(backup_region=backup_region,
-                backup_id=backup_id,
+                backup_id=new_backup_id,
                 lambda_method='do_share_backup',
                 lambda_args={}):
                 return
-            self.logger.info(f"New encrypted backup {backup_id} created")
+            self.logger.info(f"New encrypted backup {new_backup_id} created")
             created_new_encrypted_snapshot = True
         else:
             self.logger.info(f"No re-encrypt key detected")
             created_new_encrypted_snapshot = False 
             
         rds_client.modify_db_cluster_snapshot_attribute(
-            DBClusterSnapshotIdentifier=backup_id,
+            DBClusterSnapshotIdentifier=new_backup_id,
             AttributeName='restore',
             ValuesToAdd=[aws_account_id]
         )
@@ -126,7 +126,14 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
         if created_new_encrypted_snapshot:
             # delete old snapshot
             self.delete_backup(backup_resource)
-
+            
+            # re-name snapshot to old name
+            rds_client.modify_db_cluster_snapshot_attribute(
+                DBClusterSnapshotIdentifier=backup_id,
+                AttributeName='dbClusterSnapshotIdentifier',
+                ValuesToAdd=[backup_id]
+            )
+            
     def copy_backup_to_region(self, backup_id: str, region: str) -> str:
         local_region = boto3.session.Session().region_name
         client_local = AwsHelper.boto3_client('rds', arn=self.role_arn, external_id=self.role_external_id)

--- a/shelvery/rds_cluster_backup.py
+++ b/shelvery/rds_cluster_backup.py
@@ -110,16 +110,17 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
         snapshot = snapshots['DBClusterSnapshots'][0]
         backup_resource = self.get_backup_resource(local_region, backup_id)
         kms_key = RuntimeConfig.get_reencrypt_kms_key_id(backup_resource.tags, self)
-        # add kms key to params if reencrypt key is defined and rename backup
         rds_client_params = {
             'SourceDBClusterSnapshotIdentifier': snapshot['DBClusterSnapshotArn'],
             'TargetDBClusterSnapshotIdentifier': backup_id,
             'SourceRegion': local_region,
             'CopyTags': False
         }
+        # add kms key to params if reencrypt key is defined and rename backup
         if kms_key is not None:
             backup_id = f'{backup_id}-re-encrypted'
             rds_client_params['KmsKeyId'] = kms_key
+            rds_client_params['CopyTags'] = True
             rds_client_params['TargetDBClusterSnapshotIdentifier'] = backup_id
                 
         rds_client.copy_db_cluster_snapshot(**rds_client_params)

--- a/shelvery/rds_cluster_backup.py
+++ b/shelvery/rds_cluster_backup.py
@@ -102,8 +102,10 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
         # if a re-encrypt key is provided, create new re-encrypted snapshot and share that instead
         if kms_key:
             self.logger.info(f"Re-encrypt KMS Key found, creating new encrypted backup with supplied re-encrypt key")
-            # create re-encrypted backup
-            new_backup_id = self.copy_backup_to_region(backup_id, backup_region)
+            # create re-encrypted backup            
+            encrypted_backup_params = {'TargetDBClusterSnapshotIdentifier': backup_id+"-re-encrypted"}
+            new_backup_id = self.create_encrypted_backup(backup_id, backup_region)
+            new_backup_resource = self.get_backup_resource(backup_region, new_backup_id)
             self.logger.info(f"Creating new encrypted backup {new_backup_id}")
             # wait till new snapshot is available
             if not self.wait_backup_available(backup_region=backup_region,
@@ -127,14 +129,29 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
             # delete old snapshot
             self.delete_backup(backup_resource)
             
-            # re-name snapshot to old name
-            rds_client.modify_db_cluster_snapshot_attribute(
-                DBClusterSnapshotIdentifier=backup_id,
-                AttributeName='dbClusterSnapshotIdentifier',
-                ValuesToAdd=[backup_id]
-            )
-            
+            # create new snapshot to with original name
+            encrypted_backup_params = {'TargetDBClusterSnapshotIdentifier': backup_id}
+            self.create_encrypted_backup(backup_id, backup_region, encrypted_backup_params)
+        
+            # delete previous snapshot
+            self.delete_backup(new_backup_resource)
+    
     def copy_backup_to_region(self, backup_id: str, region: str) -> str:
+        local_region = boto3.session.Session().region_name
+        client_local = AwsHelper.boto3_client('rds', arn=self.role_arn, external_id=self.role_external_id)
+        rds_client = AwsHelper.boto3_client('rds', region_name=region)
+        snapshots = client_local.describe_db_cluster_snapshots(DBClusterSnapshotIdentifier=backup_id)
+        snapshot = snapshots['DBClusterSnapshots'][0]
+        rds_client.copy_db_cluster_snapshot(
+            SourceDBClusterSnapshotIdentifier=snapshot['DBClusterSnapshotArn'],
+            TargetDBClusterSnapshotIdentifier=backup_id,
+            SourceRegion=local_region,
+            # tags are created explicitly
+            CopyTags=False
+        )
+        return backup_id
+    
+    def create_encrypted_backup(self, backup_id: str, region: str, **kwargs) -> str:
         local_region = boto3.session.Session().region_name
         client_local = AwsHelper.boto3_client('rds', arn=self.role_arn, external_id=self.role_external_id)
         rds_client = AwsHelper.boto3_client('rds', region_name=region)
@@ -150,13 +167,14 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
         }
         # add kms key params if re-encrypt key is defined
         if kms_key is not None:
-            backup_id = f'{backup_id}-re-encrypted'
             rds_client_params['KmsKeyId'] = kms_key
             rds_client_params['CopyTags'] = True
-            rds_client_params['TargetDBClusterSnapshotIdentifier'] = backup_id
-                       
+        
+        #Overwrite any params as needed
+        rds_client_params.update(kwargs)               
+                
         rds_client.copy_db_cluster_snapshot(**rds_client_params)
-        return backup_id
+        return backup_id    
 
     def copy_shared_backup(self, source_account: str, source_backup: BackupResource):
         rds_client = AwsHelper.boto3_client('rds', arn=self.role_arn, external_id=self.role_external_id)

--- a/shelvery/runtime_config.py
+++ b/shelvery/runtime_config.py
@@ -62,6 +62,7 @@ class RuntimeConfig:
                             when enabled 'shelvery_copy_kms_key_id' must also be set.
     shelvery_copy_kms_key_id - when copying a shared snapshot, you can specify a different kms key used to encrypt the original snapshot.
                                Note that when copying to a new key, the shelvery requires access to both the new key and the original key.
+    shelvery_reencrypt_kms_key_id - when re-encrypting a snapshot with a new KMS key before sharing it to a new account.               
     """
 
     DEFAULT_KEEP_DAILY = 14
@@ -102,7 +103,8 @@ class RuntimeConfig:
         'shelvery_sqs_queue_wait_period': 0,
         'shelvery_ignore_invalid_resource_state': False,
         'shelvery_encrypt_copy': False,
-        'shelvery_copy_kms_key_id': None
+        'shelvery_copy_kms_key_id': None,
+        'shelvery_reencrypt_kms_key_id': None
     }
 
     @classmethod
@@ -335,3 +337,7 @@ class RuntimeConfig:
     @classmethod
     def get_copy_kms_key_id(cls, resource_tags, engine):
         return cls.get_conf_value('shelvery_copy_kms_key_id', resource_tags, engine.lambda_payload)
+    
+    @classmethod
+    def get_reencrypt_kms_key_id(cls, resource_tags, engine):
+        return cls.get_conf_value('shelvery_reencrypt_kms_key_id', resource_tags, engine.lambda_payload)

--- a/shelvery_tests/rds_cluster_integration_test.py
+++ b/shelvery_tests/rds_cluster_integration_test.py
@@ -50,7 +50,7 @@ class ShelveryRDSClusterIntegrationTestCase(unittest.TestCase):
 
        # Complete initial setup and create service client
         initSetup(self,'rds')
-        rdsclient = AwsHelper.boto3_client('docdb', region_name='ap-southeast-2')
+        rdsclient = AwsHelper.boto3_client('rds', region_name='ap-southeast-2')
 
 
         #Get cluster name


### PR DESCRIPTION
Added feature to re-encrypt RDS instance and RDS Cluster snapshots when `shelvery_reencrypt_kms_key_id` is supplied.

### RDS Cluster Example
1. We first create an RDS Cluster with shelvery backups enabled.
2. Then set the the `shelvery_reencrypt_kms_key_id` to the ARN of the new KMS key we want to re-encrypt our snapshots with aswell as `shelvery_share_aws_account_ids` with the account we are sharing with.
3. Call `shelvery rds_cluster create_backups` 
4. Shelvery will now create the initial backup as expected, however when it detects the `shelvery_reencrypt_kms_key_id` parameter is set, it will then begin creating the new re-encrypted snapshot.
```
Re-encrypt KMS Key found, creating new backup with arn:aws:kms:....
Creating new encrypted backup shelvery-test-2023-04-18-0025-daily-re-encrypted
```
Note - Shelvery updates the tags of the new snapshot to match the new name 
   - `shelvery:name : shelvery-test-2023-04-18-0025-daily-re-encrypted`
5. Shelvery will wait till the new snapshot is created, then delete the old snapshot.
```
New encrypted backup shelvery-test-2023-04-18-0025-daily-re-encrypted created
Cleaning up un-encrypted backup: shelvery-test-2023-04-18-0025-daily
Shared backup shelvery-test-2023-04-18-0025-daily-re-encrypted (ap-southeast-2) with 123456789123
Wrote meta for backup shelvery-test-2023-04-18-0025-daily-re-encrypted of type rds_cluster to s3://shelvery.data.987654321987/backups/shared/12345678123/rds_cluster/shelvery-test-2023-04-18-0025-daily-re-encrypted.yaml
```
6. Lastly, we call `shelvery rds_cluster pull_shared_backups` from our destination account, observe that Shelvery now creates the local manual snapshot in the destination account with the new re-encrypted snapshot.
<img width="792" alt="Screen Shot 2023-04-18 at 10 38 55 am" src="https://user-images.githubusercontent.com/64295670/232639672-fb8723b9-b9d2-41e8-80c8-87702958a095.png">

### RDS Instance Example
1. The process is the same for RDS instances as we set the same env vars.
2. We call `shelvery rds create_backups` 
3. Observe the re-encrypted snapshot is created as expected
```
New encrypted backup shelvery-test-instance-2023-04-18-0045-daily-re-encrypted created
Updating tags for new snapshot - shelvery-test-instance-2023-04-18-0045-daily-re-encrypted
Cleaning up un-encrypted backup: shelvery-test-instance-2023-04-18-0045-daily
Shared backup shelvery-test-instance-2023-04-18-0045-daily-re-encrypted (ap-southeast-2) with 123456789123
Wrote meta for backup shelvery-test-instance-2023-04-18-0045-daily-re-encrypted of type rds to s3://shelvery.data.987654321987-ap-southeast-2.base2tools/backups/shared/123456789123/rds/shelvery-test-instance-2023-04-18-0045-daily-re-encrypted.yaml
```
5. We call `shelvery rds pull_shared_backups` and observe the manual snapshot is created in the destination account

### Other resources
The code for re-encrypting RDS Instance and cluster snapshots should not interfere with other resource types even when the `shelvery_reencrypt_kms_key_id` as the only change to `engine.py` is to return the new backup id of the re-encrypted snapshot which only occurs for RDS resources.

```
 try:
            new_backup_id = self.share_backup_with_account(backup_region, backup_id, destination_account_id)
            #assign new backup id if new snapshot is created (eg: re-encrypted rds snapshot)
            backup_id = new_backup_id if new_backup_id else backup_id
            self.logger.info(f"Shared backup {backup_id} ({backup_region}) with {destination_account_id}")
```

