### PR TITLE
Feature/rds docdb fix

### DIFF
--- a/shelvery/rds_cluster_backup.py
+++ b/shelvery/rds_cluster_backup.py
@@ -253,16 +253,8 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
         # list of resource models
         db_clusters = []
         # temporary list of api models, as calls are batched
-        temp_clusters = rds_client.describe_db_clusters(
-                Filters=[
-                    {
-                        'Name': 'engine',
-                        'Values': [
-                            '-docdb'
-                        ]
-                    }
-                 ]
-        )
+        temp_clusters = rds_client.describe_db_clusters()
+        temp_clusters = [cluster for cluster in db_clusters if cluster.get('Engine') != 'docdb']
         db_clusters.extend(temp_clusters['DBClusters'])
         # collect database instances
         while 'Marker' in temp_clusters:

--- a/shelvery/rds_cluster_backup.py
+++ b/shelvery/rds_cluster_backup.py
@@ -251,16 +251,18 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
         :return: all RDS instances within region for given boto3 client
         """
         # list of resource models
+        rds_client = boto3.client('rds')
         db_clusters = []
         # temporary list of api models, as calls are batched
         temp_clusters = rds_client.describe_db_clusters()
-        temp_clusters = [cluster for cluster in db_clusters if cluster.get('Engine') != 'docdb']
+        
         db_clusters.extend(temp_clusters['DBClusters'])
         # collect database instances
         while 'Marker' in temp_clusters:
             temp_clusters = rds_client.describe_db_clusters(Marker=temp_clusters['Marker'])
             db_clusters.extend(temp_clusters['DBClusters'])
 
+        db_clusters = [cluster for cluster in db_clusters if cluster.get('Engine') != 'docdb']
         self.logger.info(f"Found following clusters to backup {db_clusters}")
         return db_clusters
 

--- a/shelvery/rds_cluster_backup.py
+++ b/shelvery/rds_cluster_backup.py
@@ -251,7 +251,6 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
         :return: all RDS instances within region for given boto3 client
         """
         # list of resource models
-        rds_client = boto3.client('rds')
         db_clusters = []
         # temporary list of api models, as calls are batched
         temp_clusters = rds_client.describe_db_clusters()
@@ -263,7 +262,6 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
             db_clusters.extend(temp_clusters['DBClusters'])
 
         db_clusters = [cluster for cluster in db_clusters if cluster.get('Engine') != 'docdb']
-        self.logger.info(f"Found following clusters to backup {db_clusters}")
         return db_clusters
 
     def get_shelvery_backups_only(self, all_snapshots, backup_tag_prefix, rds_client):

--- a/shelvery/rds_cluster_backup.py
+++ b/shelvery/rds_cluster_backup.py
@@ -253,7 +253,16 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
         # list of resource models
         db_clusters = []
         # temporary list of api models, as calls are batched
-        temp_clusters = rds_client.describe_db_clusters()
+        temp_clusters = rds_client.describe_db_clusters(
+                Filters=[
+                    {
+                        'Name': 'engine',
+                        'Values': [
+                            '-docdb'
+                        ]
+                    }
+                 ]
+        )
         db_clusters.extend(temp_clusters['DBClusters'])
         # collect database instances
         while 'Marker' in temp_clusters:

--- a/shelvery/rds_cluster_backup.py
+++ b/shelvery/rds_cluster_backup.py
@@ -260,6 +260,7 @@ class ShelveryRDSClusterBackup(ShelveryEngine):
             temp_clusters = rds_client.describe_db_clusters(Marker=temp_clusters['Marker'])
             db_clusters.extend(temp_clusters['DBClusters'])
 
+        self.logger.info(f"Found following clusters to backup {db_clusters}")
         return db_clusters
 
     def get_shelvery_backups_only(self, all_snapshots, backup_tag_prefix, rds_client):


### PR DESCRIPTION
Fixed bug where calling any RDS cluster function would include docdb resource's if they were present. As such docdb snapshots would be created and removed if any RDS cluster actions were invoked.

#### Example of issue:

1. For this example we have a stack with both a `docdb` and `rds_cluster` resource. No snapshots have been created yet for either.
   <img width="500" alt="Screen Shot 2023-04-21 at 3 33 13 pm" src="https://user-images.githubusercontent.com/64295670/233548626-01b67c11-8128-41ba-9b4a-0d453bdb57a1.png">

2. We call `shelvery create_backups rds_cluster`

3. We can observe in the logs immediately that shelvery has picked up the `docdb_cluster` as a resource to backup alongside our actual `rds cluster`.
   <img width="815" alt="Screen Shot 2023-04-21 at 3 35 26 pm" src="https://user-images.githubusercontent.com/64295670/233548900-f1539f82-7c17-4980-861e-8931e29b389b.png">

4. Shelvery creates a  snapshot of the `doc db cluster` aswell as a snapshot for the actual `RDS cluster`.
   <img width="817" alt="Screen Shot 2023-04-21 at 3 35 35 pm" src="https://user-images.githubusercontent.com/64295670/233548919-761adc16-678a-41e3-836c-22f4e11af88c.png">
   <img width="553" alt="Screen Shot 2023-04-21 at 3 38 34 pm" src="https://user-images.githubusercontent.com/64295670/233549310-648d405c-008f-44c7-b102-38a0a6d4dfaa.png">


#### Example of fix:
The solution was to remove any clusters from the list of clusters returned which had `Engine='docdb'`

1. With the same resources as before with no snapshots existing.
2. We call `shelvery create_backups rds_cluster`
3. This time we observe that only 1 cluster resource is picked up which is our actual RDS cluster as expected. DocDB is omitted as expected.
   <img width="819" alt="Screen Shot 2023-04-21 at 3 41 10 pm" src="https://user-images.githubusercontent.com/64295670/233549662-ed29e468-467d-4123-b3e1-0e55ac3a2bcb.png">
4. Observe no DocDB snapshot is created
   <img width="482" alt="Screen Shot 2023-04-21 at 3 41 29 pm" src="https://user-images.githubusercontent.com/64295670/233549707-b552dc1e-92a4-4372-84cd-2c05ae5e2410.png">
5. RDS Cluster snapshot is created as expected
   <img width="667" alt="Screen Shot 2023-04-21 at 3 41 40 pm" src="https://user-images.githubusercontent.com/64295670/233549736-01b0d036-b948-4696-b92e-e091f3900608.png">
