### PR TITLE
Feature/reencrypt cleanup

### DIFF
--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -8,7 +8,7 @@ import botocore
 import yaml
 import boto3
 from botocore.exceptions import ClientError
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 from typing import List, Dict
 from abc import abstractmethod
@@ -369,7 +369,7 @@ class ShelveryEngine:
                     
                     # Only delete if it's not a cross-account copy
                     if is_cross_account_copy:
-                        self.logger.info(f"Re-encrypted backup {backup.name} is a cross-account copy eg: databunker, skipping cleanup")
+                        self.logger.info(f"Re-encrypted backup {backup.name} is a cross-account copy e.g., databunker, skipping cleanup")
                     else:
                         # Check if backup is older than re-encrypt backup cleanup hours
                         current_time = datetime.now(timezone.utc).replace(tzinfo=None)

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -361,7 +361,7 @@ class ShelveryEngine:
                         'BackupName': backup.name,
                     })
                 
-                # If re-encrypt backup is older than 72 hours, clean up the backup
+                # If re-encrypt backup is older than re-encrypt backup cleanup hours, clean up the backup
                 elif '-re-encrypted' in backup.backup_id:
                     # Get tag prefix to check for cross-account copy
                     tag_prefix = backup.tags.get('shelvery:tag_name', RuntimeConfig.get_tag_prefix())
@@ -371,11 +371,11 @@ class ShelveryEngine:
                     if is_cross_account_copy:
                         self.logger.info(f"Re-encrypted backup {backup.name} is a cross-account copy eg: databunker, skipping cleanup")
                     else:
-                        # Check if backup is older than 72 hours
+                        # Check if backup is older than re-encrypt backup cleanup hours
                         age_hours = (datetime.now(timezone.utc) - backup.date_created).total_seconds() / 3600
-                        if age_hours > 72:
+                        if age_hours > RuntimeConfig.get_reencrypt_backup_cleanup_hours(self):
                             self.logger.info(
-                                f"Re-encrypted backup {backup.name} is {age_hours:.1f} hours old (> 72 hours), cleaning up")
+                                f"Re-encrypted backup {backup.name} is {age_hours:.1f} hours old (> {RuntimeConfig.get_reencrypt_backup_cleanup_hours(self)} hours), cleaning up")
                             self.delete_backup(backup)
                             # backup.date_deleted = datetime.now(timezone.utc)
                             # self._archive_backup_metadata(backup, self._get_data_bucket(), RuntimeConfig.get_share_with_accounts(self))
@@ -387,7 +387,7 @@ class ShelveryEngine:
                             #     'AgeHours': age_hours
                             #})
                         else:
-                            self.logger.info(f"Re-encrypted backup {backup.name} is {age_hours:.1f} hours old (< 72 hours), keeping")
+                            self.logger.info(f"Re-encrypted backup {backup.name} is {age_hours:.1f} hours old (< {RuntimeConfig.get_reencrypt_backup_cleanup_hours(self)} hours), keeping")
                     
                 else:
                     self.logger.info(f"{backup.retention_type} backup {backup.name} is valid "

--- a/shelvery/runtime_config.py
+++ b/shelvery/runtime_config.py
@@ -346,4 +346,4 @@ class RuntimeConfig:
     
     @classmethod
     def get_reencrypt_backup_cleanup_hours(cls, resource_tags, engine):
-        return cls.get_conf_value('shelvery_reencrypt_backup_cleanup_hours', resource_tags, engine.lambda_payload)
+        return int(cls.get_conf_value('shelvery_reencrypt_backup_cleanup_hours', resource_tags, engine.lambda_payload))

--- a/shelvery/runtime_config.py
+++ b/shelvery/runtime_config.py
@@ -63,6 +63,7 @@ class RuntimeConfig:
     shelvery_copy_kms_key_id - when copying a shared snapshot, you can specify a different kms key used to encrypt the original snapshot.
                                Note that when copying to a new key, the shelvery requires access to both the new key and the original key.
     shelvery_reencrypt_kms_key_id - when re-encrypting a snapshot with a new KMS key before sharing it to a new account.               
+    shelvery_reencrypt_backup_cleanup_hours - number of hours to keep re-encrypted backups before cleaning up. Defaults to 72 hours.
     """
 
     DEFAULT_KEEP_DAILY = 14
@@ -104,7 +105,8 @@ class RuntimeConfig:
         'shelvery_ignore_invalid_resource_state': False,
         'shelvery_encrypt_copy': False,
         'shelvery_copy_kms_key_id': None,
-        'shelvery_reencrypt_kms_key_id': None
+        'shelvery_reencrypt_kms_key_id': None,
+        'shelvery_reencrypt_backup_cleanup_hours': 72
     }
 
     @classmethod
@@ -341,3 +343,7 @@ class RuntimeConfig:
     @classmethod
     def get_reencrypt_kms_key_id(cls, resource_tags, engine):
         return cls.get_conf_value('shelvery_reencrypt_kms_key_id', resource_tags, engine.lambda_payload)
+    
+    @classmethod
+    def get_reencrypt_backup_cleanup_hours(cls, resource_tags, engine):
+        return cls.get_conf_value('shelvery_reencrypt_backup_cleanup_hours', resource_tags, engine.lambda_payload)


### PR DESCRIPTION
## Changelog
- Added logic to cleanup re-encrypted snapshots after configurable amount of time (72 hours by default)
- Doesn't cleanup re-encrypted snapshots in shared accounts (Handled by standard retention policies)

### Examples

#### New re-encrypted snapshot in source account (Less than 72 hours old, so doesn't cleanup)
```
➜  ~ shelvery rds clean_backups
Shelvery v0.9.13
2025-11-25 13:15:44,054 - root - INFO - Initialize logger
2025-11-25 13:15:44,071 - botocore.credentials - INFO - Found credentials in environment variables.
2025-11-25 13:15:44,284 - shelvery.notifications - INFO - Initialized notification service
2025-11-25 13:15:44,298 - shelvery.notifications - INFO - Initialized notification service
2025-11-25 13:15:44,752 - root - INFO - Checking RDS Snap database-1-2025-11-25-0150-daily
2025-11-25 13:15:44,755 - root - INFO - Checking RDS Snap database-1-2025-11-25-0150-daily-re-encrypted
2025-11-25 13:15:44,756 - root - INFO - Collected 2 backups to be checked for expiry date
2025-11-25 13:15:44,756 - root - INFO - Using following retention settings from runtime environment (resource overrides enabled):
                            Keeping last 14 daily backups
                            Keeping last 8 weekly backups
                            Keeping last 12 monthly backups
                            Keeping last 10 yearly backups
2025-11-25 13:15:44,756 - root - INFO - Checking backup database-1-2025-11-25-0150-daily
2025-11-25 13:15:44,756 - root - INFO - daily backup database-1-2025-11-25-0150-daily is valid until 2025-12-09 01:50:00, keeping this backup
2025-11-25 13:15:44,756 - root - INFO - Checking backup database-1-2025-11-25-0150-daily-re-encrypted
2025-11-25 13:15:44,756 - root - INFO - Re-encrypted backup database-1-2025-11-25-0150-daily is 0.4 hours old (< 72 hours), keeping
```

#### Old re-encrypted snapshot in source account (Older than 72 hours old, so gets cleantup)
```
➜  ~ shelvery rds clean_backups
Shelvery v0.9.13
2025-11-25 13:19:53,418 - root - INFO - Initialize logger
2025-11-25 13:19:53,436 - botocore.credentials - INFO - Found credentials in environment variables.
2025-11-25 13:19:53,623 - shelvery.notifications - INFO - Initialized notification service
2025-11-25 13:19:53,638 - shelvery.notifications - INFO - Initialized notification service
2025-11-25 13:19:54,051 - root - INFO - Checking RDS Snap database-1-2025-11-25-0150-daily
2025-11-25 13:19:54,054 - root - INFO - Checking RDS Snap database-1-2025-11-25-0150-daily-re-encrypted
2025-11-25 13:19:54,055 - root - INFO - Collected 2 backups to be checked for expiry date
2025-11-25 13:19:54,055 - root - INFO - Using following retention settings from runtime environment (resource overrides enabled):
                            Keeping last 14 daily backups
                            Keeping last 8 weekly backups
                            Keeping last 12 monthly backups
                            Keeping last 10 yearly backups
2025-11-25 13:19:54,055 - root - INFO - Checking backup database-1-2025-11-25-0150-daily
2025-11-25 13:19:54,055 - root - INFO - daily backup database-1-2025-11-25-0150-daily is valid until 2025-12-09 01:50:00, keeping this backup
2025-11-25 13:19:54,055 - root - INFO - Checking backup database-1-2025-11-25-0150-daily-re-encrypted
2025-11-25 13:19:54,055 - root - INFO - Re-encrypted backup database-1-2025-11-25-0150-daily is 72.5 hours old (> 72 hours), cleaning up
```

#### Any re-encrypted snapshots in non-source accounts (eg: databunkers) are not cleant up by 72 hour policy, instead standard shelvery retention cleanup policies will apply.
```
➜  ~ shelvery rds clean_backups
Shelvery v0.9.13
2025-11-25 13:16:34,407 - root - INFO - Initialize logger
2025-11-25 13:16:34,426 - botocore.credentials - INFO - Found credentials in environment variables.
2025-11-25 13:16:34,648 - shelvery.notifications - INFO - Initialized notification service
2025-11-25 13:16:34,664 - shelvery.notifications - INFO - Initialized notification service
2025-11-25 13:16:34,967 - root - INFO - Checking RDS Snap database-1-2025-11-25-0150-daily-re-encrypted
2025-11-25 13:16:34,971 - root - INFO - Collected 1 backups to be checked for expiry date
2025-11-25 13:16:34,971 - root - INFO - Using following retention settings from runtime environment (resource overrides enabled):
                            Keeping last 14 daily backups
                            Keeping last 8 weekly backups
                            Keeping last 12 monthly backups
                            Keeping last 10 yearly backups
2025-11-25 13:16:34,971 - root - INFO - Checking backup database-1-2025-11-25-0150-daily-re-encrypted
2025-11-25 13:16:34,971 - root - INFO - Re-encrypted backup database-1-2025-11-25-0150-daily is a cross-account copy eg: databunker, skipping cleanup
```