### PR TITLE
Add ebs archive for monthly and yearly

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,10 @@ backups
 - `shelvery_reencrypt_kms_key_id`  - when it is required to re-encrypt a RDS instance or cluster snapshot with a different KMS key 
                                 than that of the existing resource. Specify the ARN of the KMS Key.
 
+- `shelvery_enable_ebs_archive` - Enable EBS Snapshots Archive for monthly and yearly backups [boolean].
+  Archived snapshots are stored at a lower cost ($0.0125/GB-month vs $0.05/GB-month) but take
+  24-72 hours to restore and incur a $0.03/GB restore fee. Default: `false`.
+
 ### Configuration Priority 0: Sensible defaults
 
 ```text
@@ -337,6 +341,7 @@ shelvery_keep_monthly_backups=12
 shelvery_keep_yearly_backups=10
 shelvery_wait_snapshot_timeout=120
 shelvery_lambda_max_wait_iterations=5
+shelvery_enable_ebs_archive=false
 ```
 
 ### Configuration Priority 1: Environment variables

--- a/README.md
+++ b/README.md
@@ -328,9 +328,15 @@ backups
 - `shelvery_reencrypt_kms_key_id`  - when it is required to re-encrypt a RDS instance or cluster snapshot with a different KMS key 
                                 than that of the existing resource. Specify the ARN of the KMS Key.
 
-- `shelvery_enable_ebs_archive` - Enable EBS Snapshots Archive for monthly and yearly backups [boolean].
+- `shelvery_enable_ebs_archive` - Enable EBS Snapshots Archive for monthly and yearly backups in the
+  **source account**, after all configured share targets have pulled the snapshot [boolean].
   Archived snapshots are stored at a lower cost ($0.0125/GB-month vs $0.05/GB-month) but take
   24-72 hours to restore and incur a $0.03/GB restore fee. Default: `false`.
+  When no share accounts are configured, eligible snapshots are archived directly by
+  `archive_pending_backups`.
+
+- `shelvery_enable_ebs_archive_pulled` - Enable EBS Snapshots Archive for monthly and yearly backups in the
+  **databunker account**, immediately after a shared snapshot is pulled [boolean]. Default: `false`.
 
 ### Configuration Priority 0: Sensible defaults
 
@@ -342,6 +348,7 @@ shelvery_keep_yearly_backups=10
 shelvery_wait_snapshot_timeout=120
 shelvery_lambda_max_wait_iterations=5
 shelvery_enable_ebs_archive=false
+shelvery_enable_ebs_archive_pulled=false
 ```
 
 ### Configuration Priority 1: Environment variables
@@ -418,6 +425,36 @@ $ export shelvery_source_aws_account_ids=222222222222,333333333333
 # this command will pull backups from both accounts
 $ shelvery ebs pull_shared_backups
 ```
+
+### EBS Snapshots Archive (multi-account)
+
+When sharing EBS backups to a databunker account, snapshots must remain in the standard tier until
+the destination account has copied them. Archived snapshots cannot be copied cross-account.
+
+Flow with archive enabled:
+
+1. **Source account** — `create_backups` creates and shares snapshots as normal (no immediate archive)
+2. **Databunker account** — `pull_shared_backups` copies snapshots; optionally archives pulled copies
+   when `shelvery_enable_ebs_archive_pulled=true`
+3. **Source account** — `archive_pending_backups` scans S3 `-processed` markers and archives source
+   snapshots once all share targets have pulled them (when `shelvery_enable_ebs_archive=true`)
+
+```bash
+# Source account
+$ export shelvery_share_aws_account_ids=111111111111
+$ export shelvery_enable_ebs_archive=true
+$ shelvery ebs create_backups
+$ shelvery ebs archive_pending_backups
+
+# Databunker account
+$ export shelvery_source_aws_account_ids=222222222222
+$ export shelvery_enable_ebs_archive_pulled=true
+$ shelvery ebs pull_shared_backups
+```
+
+When deployed via SAM, `archive_pending_backups` runs on a schedule (default 03:00 UTC) after pull.
+
+Per-resource opt-out: `shelvery:config:shelvery_enable_ebs_archive=false` on the EBS volume.
 
 ## Cross-account copying of encrypted backups
 

--- a/deploy-sam-template.sh
+++ b/deploy-sam-template.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-SHELVERY_VERSION=0.9.13
+SHELVERY_VERSION=0.9.14
 
 # set DOCKERUSERID to current user. could be changed with -u uid
 DOCKERUSERID="-u $(id -u)"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-setup(name='shelvery', version='0.9.13', author='Base2Services R&D',
+setup(name='shelvery', version='0.9.14', author='Base2Services R&D',
       author_email='itsupport@base2services.com',
       url='http://github.com/base2Services/shelvery-aws-backups',
       classifiers=[

--- a/shelvery/__init__.py
+++ b/shelvery/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.9.13'
+__version__ = '0.9.14'
 LAMBDA_WAIT_ITERATION = 'lambda_wait_iteration'
 S3_DATA_PREFIX = 'backups'
 SHELVERY_DO_BACKUP_TAGS = ['True', 'true', '1', 'TRUE']

--- a/shelvery/ebs_backup.py
+++ b/shelvery/ebs_backup.py
@@ -8,6 +8,7 @@ from shelvery.engine import SHELVERY_DO_BACKUP_TAGS
 from shelvery.ec2_backup import ShelveryEC2Backup
 from shelvery.entity_resource import EntityResource
 from shelvery.backup_resource import BackupResource
+from shelvery.runtime_config import RuntimeConfig
 
 
 class ShelveryEBSBackup(ShelveryEC2Backup):
@@ -65,6 +66,25 @@ class ShelveryEBSBackup(ShelveryEC2Backup):
         )
         backup_resource.backup_id = snap['SnapshotId']
         return backup_resource
+
+    def archive_backup(self, backup_resource: BackupResource):
+        """Move snapshot to the EBS Snapshots Archive tier for long-term storage."""
+        ec2client = AwsHelper.boto3_client('ec2', arn=self.role_arn, external_id=self.role_external_id)
+        ec2client.modify_snapshot_tier(
+            SnapshotId=backup_resource.backup_id,
+            StorageTier='archive'
+        )
+        self.logger.info(f"Initiated archive of snapshot {backup_resource.backup_id}")
+
+    def post_create_backups(self, backup_resources):
+        """Archive monthly/yearly EBS snapshots if archiving is enabled."""
+        for br in backup_resources:
+            if (RuntimeConfig.get_enable_ebs_archive(br.entity_resource.tags, self)
+                    and br.retention_type in [BackupResource.RETENTION_MONTHLY, BackupResource.RETENTION_YEARLY]):
+                try:
+                    self.archive_backup(br)
+                except Exception as e:
+                    self.logger.exception(f"Failed to archive snapshot {br.backup_id}: {e}")
 
     def get_backup_resource(self, region: str, backup_id: str) -> BackupResource:
         ec2 = AwsHelper.boto3_session('ec2', region_name=region, arn=self.role_arn, external_id=self.role_external_id)

--- a/shelvery/ebs_backup.py
+++ b/shelvery/ebs_backup.py
@@ -82,6 +82,7 @@ class ShelveryEBSBackup(ShelveryEC2Backup):
             if (RuntimeConfig.get_enable_ebs_archive(br.entity_resource.tags, self)
                     and br.retention_type in [BackupResource.RETENTION_MONTHLY, BackupResource.RETENTION_YEARLY]):
                 try:
+                    self.wait_backup_available(br.region, br.backup_id, None, None)
                     self.archive_backup(br)
                 except Exception as e:
                     self.logger.exception(f"Failed to archive snapshot {br.backup_id}: {e}")

--- a/shelvery/ebs_backup.py
+++ b/shelvery/ebs_backup.py
@@ -1,6 +1,7 @@
 import boto3
+import yaml
 
-from typing import List
+from typing import Dict, List, Tuple
 
 from botocore.exceptions import ClientError
 from shelvery.aws_helper import AwsHelper
@@ -9,6 +10,7 @@ from shelvery.ec2_backup import ShelveryEC2Backup
 from shelvery.entity_resource import EntityResource
 from shelvery.backup_resource import BackupResource
 from shelvery.runtime_config import RuntimeConfig
+from shelvery import S3_DATA_PREFIX
 
 
 class ShelveryEBSBackup(ShelveryEC2Backup):
@@ -76,33 +78,214 @@ class ShelveryEBSBackup(ShelveryEC2Backup):
         )
         self.logger.info(f"Initiated archive of snapshot {backup_resource.backup_id}")
 
-    def _will_archive(self, backup_resource: BackupResource) -> bool:
-        return (RuntimeConfig.get_enable_ebs_archive(backup_resource.entity_resource.tags, self)
-                and backup_resource.retention_type in [BackupResource.RETENTION_MONTHLY, BackupResource.RETENTION_YEARLY])
+    def _config_tags_from_backup(self, backup_resource: BackupResource) -> Dict[str, str]:
+        tags = backup_resource.entity_resource_tags()
+        if tags:
+            return tags
+        tag_prefix = backup_resource.tags.get('shelvery:tag_name', RuntimeConfig.get_tag_prefix())
+        config_tags = {}
+        for key, value in backup_resource.tags.items():
+            if key.startswith(f"{tag_prefix}:config:"):
+                config_tags[f"shelvery:config:{key.split(':config:', 1)[1]}"] = value
+            elif key.startswith('shelvery:config:'):
+                config_tags[key] = value
+        return config_tags
 
-    def is_backup_shareable(self, backup_resource: BackupResource) -> bool:
-        """Archived EBS snapshots cannot be copied cross-account, so exclude
-        them from sharing to prevent destination pull operations from hanging."""
-        if self._will_archive(backup_resource):
+    def _is_monthly_or_yearly(self, backup_resource: BackupResource) -> bool:
+        return backup_resource.retention_type in [
+            BackupResource.RETENTION_MONTHLY,
+            BackupResource.RETENTION_YEARLY,
+        ]
+
+    def _should_archive_source(self, backup_resource: BackupResource) -> bool:
+        tags = self._config_tags_from_backup(backup_resource)
+        return (RuntimeConfig.get_enable_ebs_archive(tags or None, self)
+                and self._is_monthly_or_yearly(backup_resource))
+
+    def _should_archive_pulled(self, backup_resource: BackupResource) -> bool:
+        tags = self._config_tags_from_backup(backup_resource)
+        return (RuntimeConfig.get_enable_ebs_archive_pulled(tags or None, self)
+                and self._is_monthly_or_yearly(backup_resource))
+
+    def _snapshot_is_standard_tier(self, backup_resource: BackupResource) -> bool:
+        try:
+            regional_client = AwsHelper.boto3_client(
+                'ec2',
+                region_name=backup_resource.region,
+                arn=self.role_arn,
+                external_id=self.role_external_id,
+            )
+            snapshot = regional_client.describe_snapshots(
+                SnapshotIds=[backup_resource.backup_id]
+            )['Snapshots'][0]
+            return snapshot.get('StorageTier', 'standard') == 'standard'
+        except Exception as e:
+            self.logger.warn(
+                f"Could not determine storage tier for snapshot {backup_resource.backup_id}: {e}"
+            )
             return False
-        return True
 
-    def post_create_backups(self, backup_resources):
-        """Archive monthly/yearly EBS snapshots if archiving is enabled.
+    def archive_pending_backups(self):
+        """Archive source-account snapshots after all share targets have pulled them.
 
-        Note: In Lambda, waiting sequentially for multiple snapshots could
-        approach the 15-minute execution limit. The per-snapshot wait respects
-        the remaining Lambda execution time, so later snapshots may fail to
-        archive if insufficient time remains. Failures are logged but do not
-        block other operations.
+        When no share accounts are configured, archives eligible local snapshots directly.
         """
-        for br in backup_resources:
-            if self._will_archive(br):
-                try:
-                    self.wait_backup_available(br.region, br.backup_id, None, None)
-                    self.archive_backup(br)
-                except Exception as e:
-                    self.logger.exception(f"Failed to archive snapshot {br.backup_id}: {e}")
+        if not RuntimeConfig.get_enable_ebs_archive(None, self):
+            self.logger.info("EBS source archive disabled, skipping archive_pending_backups")
+            return
+
+        share_accounts = RuntimeConfig.get_share_with_accounts(self)
+        if not share_accounts:
+            self._archive_standalone_backups()
+            return
+
+        bucket = self._get_data_bucket()
+        bucket_name = bucket.name
+        regional_client = self._get_s3_regional_client(bucket_name)
+        engine_type = self.get_engine_type()
+
+        ready_backups = self._collect_backups_ready_for_source_archive(
+            share_accounts, bucket_name, regional_client, engine_type
+        )
+
+        for backup, accounts_with_processed in ready_backups:
+            self._archive_source_backup_if_eligible(
+                backup, accounts_with_processed, bucket_name, regional_client
+            )
+
+    def post_pull_backups(self, backup_resources):
+        """Archive pulled copies in the databunker account when enabled."""
+        for backup in backup_resources:
+            if not self._should_archive_pulled(backup):
+                continue
+            try:
+                self.wait_backup_available(backup.region, backup.backup_id, None, None)
+                self.archive_backup(backup)
+            except Exception as e:
+                self.logger.exception(f"Failed to archive pulled snapshot {backup.backup_id}: {e}")
+
+    def _archive_standalone_backups(self):
+        tag_prefix = RuntimeConfig.get_tag_prefix()
+        for backup in self.get_existing_backups(tag_prefix):
+            if not self._should_archive_source(backup):
+                continue
+            if not self._snapshot_is_standard_tier(backup):
+                continue
+            try:
+                self.wait_backup_available(backup.region, backup.backup_id, None, None)
+                self.archive_backup(backup)
+            except Exception as e:
+                self.logger.exception(f"Failed to archive snapshot {backup.backup_id}: {e}")
+
+    def _collect_backups_ready_for_source_archive(
+        self,
+        share_accounts: List[str],
+        bucket_name: str,
+        regional_client,
+        engine_type: str,
+    ) -> List[Tuple[BackupResource, Dict[str, str]]]:
+        processed_by_name: Dict[str, Dict[str, str]] = {}
+
+        for dest_account in share_accounts:
+            path_processed = f"{S3_DATA_PREFIX}/shared/{dest_account}/{engine_type}-processed/"
+            path_archived = f"{S3_DATA_PREFIX}/shared/{dest_account}/{engine_type}-archived/"
+
+            for obj in self._list_s3_objects(regional_client, bucket_name, path_processed):
+                name = self._backup_name_from_s3_key(obj['Key'])
+                archived_key = f"{path_archived}{name}.yaml"
+                if self._s3_object_exists(regional_client, bucket_name, archived_key):
+                    continue
+                if name not in processed_by_name:
+                    processed_by_name[name] = {}
+                processed_by_name[name][dest_account] = obj['Key']
+
+        ready = []
+        share_account_set = set(share_accounts)
+        for name, accounts_with_processed in processed_by_name.items():
+            if set(accounts_with_processed.keys()) == share_account_set:
+                processed_key = next(iter(accounts_with_processed.values()))
+                backup = self._load_backup_from_s3(regional_client, bucket_name, processed_key)
+                ready.append((backup, accounts_with_processed))
+
+        return ready
+
+    def _archive_source_backup_if_eligible(
+        self,
+        backup: BackupResource,
+        accounts_with_processed: Dict[str, str],
+        bucket_name: str,
+        regional_client,
+    ):
+        if not self._should_archive_source(backup):
+            return
+        if not self._snapshot_is_standard_tier(backup):
+            return
+        try:
+            self.wait_backup_available(backup.region, backup.backup_id, None, None)
+            self.archive_backup(backup)
+            self._move_processed_to_archived(
+                backup, accounts_with_processed, bucket_name, regional_client
+            )
+        except Exception as e:
+            self.logger.exception(f"Failed to archive snapshot {backup.backup_id}: {e}")
+
+    def _move_processed_to_archived(
+        self,
+        backup: BackupResource,
+        accounts_with_processed: Dict[str, str],
+        bucket_name: str,
+        regional_client,
+    ):
+        engine_type = self.get_engine_type()
+        for dest_account, processed_key in accounts_with_processed.items():
+            archived_key = (
+                f"{S3_DATA_PREFIX}/shared/{dest_account}/{engine_type}-archived/{backup.name}.yaml"
+            )
+            body = regional_client.get_object(Bucket=bucket_name, Key=processed_key)['Body'].read()
+            regional_client.put_object(Bucket=bucket_name, Key=archived_key, Body=body)
+            regional_client.delete_object(Bucket=bucket_name, Key=processed_key)
+            self.logger.info(f"Moved shared backup info to s3://{bucket_name}/{archived_key}")
+
+    def _get_s3_regional_client(self, bucket_name: str):
+        s3_client = AwsHelper.boto3_client('s3')
+        bucket_loc = s3_client.get_bucket_location(Bucket=bucket_name)
+        bucket_region = bucket_loc['LocationConstraint']
+        if bucket_region == 'EU':
+            bucket_region = 'eu-west-1'
+        elif bucket_region is None:
+            bucket_region = 'us-east-1'
+        return AwsHelper.boto3_client('s3', region_name=bucket_region)
+
+    def _list_s3_objects(self, regional_client, bucket_name: str, prefix: str) -> List[dict]:
+        all_objects = []
+        response = regional_client.list_objects_v2(Bucket=bucket_name, Prefix=prefix)
+        if 'Contents' in response:
+            all_objects.extend(response['Contents'])
+        while 'NextContinuationToken' in response:
+            response = regional_client.list_objects_v2(
+                Bucket=bucket_name,
+                Prefix=prefix,
+                ContinuationToken=response['NextContinuationToken'],
+            )
+            if 'Contents' in response:
+                all_objects.extend(response['Contents'])
+        return all_objects
+
+    def _s3_object_exists(self, regional_client, bucket_name: str, key: str) -> bool:
+        try:
+            regional_client.head_object(Bucket=bucket_name, Key=key)
+            return True
+        except ClientError as e:
+            if e.response['Error']['Code'] == '404':
+                return False
+            raise
+
+    def _backup_name_from_s3_key(self, key: str) -> str:
+        return key.split('/')[-1].replace('.yaml', '')
+
+    def _load_backup_from_s3(self, regional_client, bucket_name: str, key: str) -> BackupResource:
+        serialised = regional_client.get_object(Bucket=bucket_name, Key=key)['Body'].read()
+        return yaml.load(serialised, Loader=yaml.Loader)
 
     def get_backup_resource(self, region: str, backup_id: str) -> BackupResource:
         ec2 = AwsHelper.boto3_session('ec2', region_name=region, arn=self.role_arn, external_id=self.role_external_id)

--- a/shelvery/ebs_backup.py
+++ b/shelvery/ebs_backup.py
@@ -76,6 +76,17 @@ class ShelveryEBSBackup(ShelveryEC2Backup):
         )
         self.logger.info(f"Initiated archive of snapshot {backup_resource.backup_id}")
 
+    def _will_archive(self, backup_resource: BackupResource) -> bool:
+        return (RuntimeConfig.get_enable_ebs_archive(backup_resource.entity_resource.tags, self)
+                and backup_resource.retention_type in [BackupResource.RETENTION_MONTHLY, BackupResource.RETENTION_YEARLY])
+
+    def is_backup_shareable(self, backup_resource: BackupResource) -> bool:
+        """Archived EBS snapshots cannot be copied cross-account, so exclude
+        them from sharing to prevent destination pull operations from hanging."""
+        if self._will_archive(backup_resource):
+            return False
+        return True
+
     def post_create_backups(self, backup_resources):
         """Archive monthly/yearly EBS snapshots if archiving is enabled.
 
@@ -86,8 +97,7 @@ class ShelveryEBSBackup(ShelveryEC2Backup):
         block other operations.
         """
         for br in backup_resources:
-            if (RuntimeConfig.get_enable_ebs_archive(br.entity_resource.tags, self)
-                    and br.retention_type in [BackupResource.RETENTION_MONTHLY, BackupResource.RETENTION_YEARLY]):
+            if self._will_archive(br):
                 try:
                     self.wait_backup_available(br.region, br.backup_id, None, None)
                     self.archive_backup(br)

--- a/shelvery/ebs_backup.py
+++ b/shelvery/ebs_backup.py
@@ -77,7 +77,14 @@ class ShelveryEBSBackup(ShelveryEC2Backup):
         self.logger.info(f"Initiated archive of snapshot {backup_resource.backup_id}")
 
     def post_create_backups(self, backup_resources):
-        """Archive monthly/yearly EBS snapshots if archiving is enabled."""
+        """Archive monthly/yearly EBS snapshots if archiving is enabled.
+
+        Note: In Lambda, waiting sequentially for multiple snapshots could
+        approach the 15-minute execution limit. The per-snapshot wait respects
+        the remaining Lambda execution time, so later snapshots may fail to
+        archive if insufficient time remains. Failures are logged but do not
+        block other operations.
+        """
         for br in backup_resources:
             if (RuntimeConfig.get_enable_ebs_archive(br.entity_resource.tags, self)
                     and br.retention_type in [BackupResource.RETENTION_MONTHLY, BackupResource.RETENTION_YEARLY]):

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -319,7 +319,11 @@ class ShelveryEngine:
 
         for aws_account_id in RuntimeConfig.get_share_with_accounts(self):
             for br in backup_resources:
-                self.share_backup(br, aws_account_id)
+                if self.is_backup_shareable(br):
+                    self.share_backup(br, aws_account_id)
+                else:
+                    self.logger.info(f"Skipping share of backup {br.name} with account {aws_account_id} "
+                                     f"- backup is not eligible for cross-account sharing")
 
         self.post_create_backups(backup_resources)
 
@@ -585,6 +589,12 @@ class ShelveryEngine:
                 'Region': region
             }
             ShelveryInvoker().invoke_shelvery_operation(self, method, arguments)
+
+    def is_backup_shareable(self, backup_resource: BackupResource) -> bool:
+        """Check whether a backup resource is eligible for cross-account sharing.
+        Subclasses can override to exclude backups that cannot be copied cross-account
+        (e.g. EBS snapshots destined for archive tier)."""
+        return True
 
     def share_backup(self, backup_resource: BackupResource, aws_account_id: str):
         """

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -333,6 +333,14 @@ class ShelveryEngine:
         """Hook called after all backups are created, copied, and shared. Override in subclasses."""
         pass
 
+    def post_pull_backups(self, backup_resources):
+        """Hook called after shared backups are copied into this account. Override in subclasses."""
+        pass
+
+    def archive_pending_backups(self):
+        """Archive backups that are ready for long-term storage. Override in subclasses."""
+        pass
+
     def clean_backups(self):
         # collect backups
         existing_backups = self.get_existing_backups(RuntimeConfig.get_tag_prefix())
@@ -463,6 +471,7 @@ class ShelveryEngine:
                         new_backup = shared_backup.cross_account_copy(new_backup_id)
                         self.tag_backup_resource(new_backup)
                         self.store_backup_data(new_backup)
+                        self.post_pull_backups([new_backup])
                         regional_client.delete_object(Bucket=bucket_name, Key=backup_object['Key'])
                         self.logger.info(f"Removed s3://{bucket_name}/{backup_object['Key']}")
                         regional_client.put_object(

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -321,7 +321,13 @@ class ShelveryEngine:
             for br in backup_resources:
                 self.share_backup(br, aws_account_id)
 
+        self.post_create_backups(backup_resources)
+
         return backup_resources
+
+    def post_create_backups(self, backup_resources):
+        """Hook called after all backups are created, copied, and shared. Override in subclasses."""
+        pass
 
     def clean_backups(self):
         # collect backups

--- a/shelvery/runtime_config.py
+++ b/shelvery/runtime_config.py
@@ -65,7 +65,10 @@ class RuntimeConfig:
     shelvery_reencrypt_kms_key_id - when re-encrypting a snapshot with a new KMS key before sharing it to a new account.               
     shelvery_reencrypt_backup_cleanup_hours - number of hours to keep re-encrypted backups before cleaning up. Defaults to 72 hours.
 
-    shelvery_enable_ebs_archive - enable archiving monthly/yearly EBS snapshots to EBS Snapshots Archive tier. Defaults to false (opt-in).
+    shelvery_enable_ebs_archive - enable archiving monthly/yearly EBS snapshots to EBS Snapshots Archive tier
+        in the source account after all share targets have pulled them. Defaults to false (opt-in).
+    shelvery_enable_ebs_archive_pulled - enable archiving monthly/yearly EBS snapshots in the databunker account
+        immediately after they are pulled. Defaults to false (opt-in).
     """
 
     DEFAULT_KEEP_DAILY = 14
@@ -109,7 +112,8 @@ class RuntimeConfig:
         'shelvery_copy_kms_key_id': None,
         'shelvery_reencrypt_kms_key_id': None,
         'shelvery_reencrypt_backup_cleanup_hours': 72,
-        'shelvery_enable_ebs_archive': False
+        'shelvery_enable_ebs_archive': False,
+        'shelvery_enable_ebs_archive_pulled': False
     }
 
     @classmethod
@@ -354,4 +358,9 @@ class RuntimeConfig:
     @classmethod
     def get_enable_ebs_archive(cls, resource_tags=None, engine=None):
         val = cls.get_conf_value('shelvery_enable_ebs_archive', resource_tags, engine.lambda_payload if engine else None)
+        return str(val).lower() in ['true', '1', 'yes']
+
+    @classmethod
+    def get_enable_ebs_archive_pulled(cls, resource_tags=None, engine=None):
+        val = cls.get_conf_value('shelvery_enable_ebs_archive_pulled', resource_tags, engine.lambda_payload if engine else None)
         return str(val).lower() in ['true', '1', 'yes']

--- a/shelvery/runtime_config.py
+++ b/shelvery/runtime_config.py
@@ -353,5 +353,5 @@ class RuntimeConfig:
 
     @classmethod
     def get_enable_ebs_archive(cls, resource_tags=None, engine=None):
-        val = cls.get_conf_value('shelvery_enable_ebs_archive', resource_tags, engine.lambda_payload)
+        val = cls.get_conf_value('shelvery_enable_ebs_archive', resource_tags, engine.lambda_payload if engine else None)
         return str(val).lower() in ['true', '1', 'yes']

--- a/shelvery/runtime_config.py
+++ b/shelvery/runtime_config.py
@@ -64,6 +64,8 @@ class RuntimeConfig:
                                Note that when copying to a new key, the shelvery requires access to both the new key and the original key.
     shelvery_reencrypt_kms_key_id - when re-encrypting a snapshot with a new KMS key before sharing it to a new account.               
     shelvery_reencrypt_backup_cleanup_hours - number of hours to keep re-encrypted backups before cleaning up. Defaults to 72 hours.
+
+    shelvery_enable_ebs_archive - enable archiving monthly/yearly EBS snapshots to EBS Snapshots Archive tier. Defaults to false (opt-in).
     """
 
     DEFAULT_KEEP_DAILY = 14
@@ -106,7 +108,8 @@ class RuntimeConfig:
         'shelvery_encrypt_copy': False,
         'shelvery_copy_kms_key_id': None,
         'shelvery_reencrypt_kms_key_id': None,
-        'shelvery_reencrypt_backup_cleanup_hours': 72
+        'shelvery_reencrypt_backup_cleanup_hours': 72,
+        'shelvery_enable_ebs_archive': False
     }
 
     @classmethod
@@ -347,3 +350,8 @@ class RuntimeConfig:
     @classmethod
     def get_reencrypt_backup_cleanup_hours(cls, resource_tags, engine):
         return int(cls.get_conf_value('shelvery_reencrypt_backup_cleanup_hours', resource_tags, engine.lambda_payload))
+
+    @classmethod
+    def get_enable_ebs_archive(cls, resource_tags=None, engine=None):
+        val = cls.get_conf_value('shelvery_enable_ebs_archive', resource_tags, engine.lambda_payload)
+        return str(val).lower() in ['true', '1', 'yes']

--- a/shelvery_cli/__main__.py
+++ b/shelvery_cli/__main__.py
@@ -28,7 +28,7 @@ def main(args=None):
         args.insert(0, 'ebs')
     if len(args) < 2:
         print("""Usage: shelvery <backup_type> <action>\n\nBackup types: rds ebs rds_cluster ec2ami redshift
-Actions:\n\tcreate_backups\n\tclean_backups\n\tcreate_data_buckets\n\tpull_shared_backups""")
+Actions:\n\tcreate_backups\n\tclean_backups\n\tcreate_data_buckets\n\tpull_shared_backups\n\tarchive_pending_backups""")
         exit(-2)
 
     setup_logging()

--- a/shelvery_tests/ebs_archive_integration_test.py
+++ b/shelvery_tests/ebs_archive_integration_test.py
@@ -148,6 +148,8 @@ class ShelveryEBSArchiveIntegrationTestCase(unittest.TestCase):
                 self.assertEqual(backup.retention_type, 'monthly')
 
         # Cleanup
+        # Note: Snapshots in 'archival-in-progress' state should still be deletable
+        # via the EC2 API. If cleanup fails, orphaned snapshots may need manual removal.
         print("Cleaning up EBS Archive test backups")
         backups_engine.clean_backups()
 

--- a/shelvery_tests/ebs_archive_integration_test.py
+++ b/shelvery_tests/ebs_archive_integration_test.py
@@ -1,0 +1,231 @@
+import sys
+import unittest
+import pytest
+import os
+import time
+from botocore.exceptions import WaiterError
+from shelvery.engine import ShelveryEngine
+from shelvery.runtime_config import RuntimeConfig
+from shelvery.ebs_backup import ShelveryEBSBackup
+from shelvery.aws_helper import AwsHelper
+from shelvery_tests.test_functions import setup_source
+from shelvery_tests.resources import EBS_INSTANCE_RESOURCE_NAME, ResourceClass
+
+pwd = os.path.dirname(os.path.abspath(__file__))
+
+sys.path.append(f"{pwd}/..")
+sys.path.append(f"{pwd}/../shelvery")
+sys.path.append(f"{pwd}/shelvery")
+sys.path.append(f"{pwd}/lib")
+sys.path.append(f"{pwd}/../lib")
+
+print(f"Python lib path:\n{sys.path}")
+
+
+class EBSArchiveTestClass(ResourceClass):
+
+    def __init__(self):
+        self.resource_name = EBS_INSTANCE_RESOURCE_NAME
+        self.backups_engine = ShelveryEBSBackup()
+        self.client = AwsHelper.boto3_client('ec2', region_name='ap-southeast-2')
+        self.resource_id = self.get_instance_id()
+
+    def add_backup_tags(self):
+        self.client.create_tags(
+            Resources=[self.resource_id],
+            Tags=[{
+                'Key': f"{RuntimeConfig.get_tag_prefix()}:{ShelveryEngine.BACKUP_RESOURCE_TAG}",
+                'Value': 'true'
+            },
+                {'Key': 'Name',
+                 'Value': self.resource_name
+                 }]
+        )
+
+    def get_instance_id(self):
+        search_filter = [{'Name': 'tag:Name', 'Values': [self.resource_name]}]
+        ebs_volumes = self.client.describe_volumes(Filters=search_filter)
+        try:
+            return ebs_volumes['Volumes'][0]['VolumeId']
+        except (IndexError, KeyError):
+            print("No EBS volumes found matching the given criteria.")
+            return ""
+
+    def wait_for_resource(self):
+        waiter = AwsHelper.boto3_client('ec2', region_name='ap-southeast-2').get_waiter('volume_available')
+        try:
+            waiter.wait(
+                VolumeIds=[self.resource_id],
+                WaiterConfig={
+                    'Delay': 30,
+                    'MaxAttempts': 50
+                }
+            )
+        except WaiterError as error:
+            print("Waiting for EBS Volume Failed")
+            print(error)
+            raise error
+
+
+class ShelveryEBSArchiveIntegrationTestCase(unittest.TestCase):
+    """Integration tests for EBS Snapshots Archive tier feature.
+
+    These tests require real AWS credentials and an EBS volume tagged
+    for shelvery backups. They verify that the archive tier API is
+    called correctly for monthly retention type backups.
+    """
+
+    def id(self):
+        return str(self.__class__)
+
+    def setUp(self):
+        self.created_snapshots = []
+        self.regional_snapshots = []
+        setup_source(self)
+
+        # Enable archive feature and force monthly retention for test
+        os.environ['shelvery_enable_ebs_archive'] = 'true'
+        os.environ['shelvery_current_retention_type'] = 'monthly'
+
+        ebs_test_class = EBSArchiveTestClass()
+        ebs_test_class.wait_for_resource()
+        ebs_test_class.add_backup_tags()
+
+    @pytest.mark.source
+    def test_CreateEbsBackupWithArchive(self):
+        """Create an EBS backup with monthly retention and verify it is archived."""
+        print("Running EBS archive integration test")
+        ebs_test_class = EBSArchiveTestClass()
+        backups_engine = ebs_test_class.backups_engine
+        client = ebs_test_class.client
+
+        backups = backups_engine.create_backups()
+        print(f"Created {len(backups)} backups for EBS Volume")
+
+        self.assertGreater(len(backups), 0, "Expected at least 1 backup")
+
+        for backup in backups:
+            snapshot_id = backup.backup_id
+            self.created_snapshots.append(snapshot_id)
+            print(f"Checking archive status for snapshot {snapshot_id}")
+
+            # Wait for snapshot to be available before checking tier
+            backups_engine.wait_backup_available(backup.region, snapshot_id, None, None)
+
+            # Allow time for the archive tier transition to be initiated
+            time.sleep(5)
+
+            # Describe the snapshot to check storage tier
+            response = client.describe_snapshots(SnapshotIds=[snapshot_id])
+            snapshot = response['Snapshots'][0]
+
+            # The snapshot should either be archiving or already archived
+            # Note: StorageTier may show 'standard' briefly while archival is in progress,
+            # but describe_snapshot_tier_status should show the tiering status
+            print(f"Snapshot {snapshot_id} StorageTier: {snapshot.get('StorageTier', 'standard')}")
+
+            # Check tiering status via describe_snapshot_tier_status
+            tier_response = client.describe_snapshot_tier_status(
+                Filters=[{'Name': 'snapshot-id', 'Values': [snapshot_id]}]
+            )
+
+            if tier_response.get('SnapshotTierStatuses'):
+                tier_status = tier_response['SnapshotTierStatuses'][0]
+                print(f"Tiering status: {tier_status.get('Status', 'N/A')}")
+                print(f"Storage tier: {tier_status.get('StorageTier', 'N/A')}")
+                # Status should be 'archival-in-progress' or 'archival-completed'
+                self.assertIn(
+                    tier_status.get('Status', ''),
+                    ['archival-in-progress', 'archival-completed'],
+                    f"Snapshot {snapshot_id} should be archiving or archived"
+                )
+            else:
+                # If the API doesn't return status immediately, the modify call was made
+                # This can happen with very new snapshots
+                print(f"No tier status yet for {snapshot_id} - verifying via retention type")
+                self.assertEqual(backup.retention_type, 'monthly')
+
+        # Cleanup
+        print("Cleaning up EBS Archive test backups")
+        backups_engine.clean_backups()
+
+    @pytest.mark.source
+    def test_CreateEbsBackupArchiveDisabled(self):
+        """Create an EBS backup with archive disabled and verify it stays standard."""
+        print("Running EBS archive disabled test")
+        os.environ['shelvery_enable_ebs_archive'] = 'false'
+
+        ebs_test_class = EBSArchiveTestClass()
+        backups_engine = ebs_test_class.backups_engine
+        client = ebs_test_class.client
+
+        backups = backups_engine.create_backups()
+        print(f"Created {len(backups)} backups for EBS Volume")
+
+        self.assertGreater(len(backups), 0, "Expected at least 1 backup")
+
+        for backup in backups:
+            snapshot_id = backup.backup_id
+            self.created_snapshots.append(snapshot_id)
+
+            backups_engine.wait_backup_available(backup.region, snapshot_id, None, None)
+            time.sleep(5)
+
+            response = client.describe_snapshots(SnapshotIds=[snapshot_id])
+            snapshot = response['Snapshots'][0]
+
+            # Snapshot should remain in standard tier
+            storage_tier = snapshot.get('StorageTier', 'standard')
+            print(f"Snapshot {snapshot_id} StorageTier: {storage_tier}")
+            self.assertEqual(storage_tier, 'standard',
+                             f"Snapshot {snapshot_id} should remain in standard tier when archive is disabled")
+
+        # Cleanup
+        print("Cleaning up EBS Archive disabled test backups")
+        backups_engine.clean_backups()
+
+    @pytest.mark.source
+    def test_CreateDailyEbsBackupNotArchived(self):
+        """Create an EBS backup with daily retention and verify it is NOT archived."""
+        print("Running EBS daily backup (no archive) test")
+        os.environ['shelvery_enable_ebs_archive'] = 'true'
+        os.environ['shelvery_current_retention_type'] = 'daily'
+
+        ebs_test_class = EBSArchiveTestClass()
+        backups_engine = ebs_test_class.backups_engine
+        client = ebs_test_class.client
+
+        backups = backups_engine.create_backups()
+        print(f"Created {len(backups)} backups for EBS Volume")
+
+        self.assertGreater(len(backups), 0, "Expected at least 1 backup")
+
+        for backup in backups:
+            snapshot_id = backup.backup_id
+            self.created_snapshots.append(snapshot_id)
+
+            backups_engine.wait_backup_available(backup.region, snapshot_id, None, None)
+            time.sleep(5)
+
+            response = client.describe_snapshots(SnapshotIds=[snapshot_id])
+            snapshot = response['Snapshots'][0]
+
+            storage_tier = snapshot.get('StorageTier', 'standard')
+            print(f"Snapshot {snapshot_id} StorageTier: {storage_tier}")
+            self.assertEqual(storage_tier, 'standard',
+                             f"Daily snapshot {snapshot_id} should NOT be archived")
+
+        # Cleanup
+        print("Cleaning up daily backup test")
+        backups_engine.clean_backups()
+
+    def tearDown(self):
+        # Reset env vars
+        os.environ.pop('shelvery_enable_ebs_archive', None)
+        os.environ.pop('shelvery_current_retention_type', None)
+        print("Waiting 30s due to EBS Snapshot rate limit...")
+        time.sleep(30)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/shelvery_tests/ebs_archive_integration_test.py
+++ b/shelvery_tests/ebs_archive_integration_test.py
@@ -131,12 +131,14 @@ class ShelveryEBSArchiveIntegrationTestCase(unittest.TestCase):
 
             if tier_response.get('SnapshotTierStatuses'):
                 tier_status = tier_response['SnapshotTierStatuses'][0]
-                print(f"Tiering status: {tier_status.get('Status', 'N/A')}")
+                status = tier_status.get('Status', '')
+                print(f"Tiering status: {status}")
                 print(f"Storage tier: {tier_status.get('StorageTier', 'N/A')}")
-                # Status should be 'archival-in-progress' or 'archival-completed'
+                # The API returns 'archival-in-progress' while archiving,
+                # and 'completed' once the archive operation finishes
                 self.assertIn(
-                    tier_status.get('Status', ''),
-                    ['archival-in-progress', 'archival-completed'],
+                    status,
+                    ['archival-in-progress', 'completed'],
                     f"Snapshot {snapshot_id} should be archiving or archived"
                 )
             else:

--- a/shelvery_tests/ebs_archive_integration_test.py
+++ b/shelvery_tests/ebs_archive_integration_test.py
@@ -71,8 +71,8 @@ class ShelveryEBSArchiveIntegrationTestCase(unittest.TestCase):
     """Integration tests for EBS Snapshots Archive tier feature.
 
     These tests require real AWS credentials and an EBS volume tagged
-    for shelvery backups. They verify that the archive tier API is
-    called correctly for monthly retention type backups.
+    for shelvery backups. They verify archive runs after backup creation
+    via archive_pending_backups (standalone mode).
     """
 
     def id(self):
@@ -83,17 +83,17 @@ class ShelveryEBSArchiveIntegrationTestCase(unittest.TestCase):
         self.regional_snapshots = []
         setup_source(self)
 
-        # Enable archive feature and force monthly retention for test
         os.environ['shelvery_enable_ebs_archive'] = 'true'
         os.environ['shelvery_current_retention_type'] = 'monthly'
+        os.environ['shelvery_share_aws_account_ids'] = ''
 
         ebs_test_class = EBSArchiveTestClass()
         ebs_test_class.wait_for_resource()
         ebs_test_class.add_backup_tags()
 
     @pytest.mark.source
-    def test_CreateEbsBackupWithArchive(self):
-        """Create an EBS backup with monthly retention and verify it is archived."""
+    def test_CreateEbsBackupThenArchivePending(self):
+        """Create backup (no immediate archive), then archive via archive_pending_backups."""
         print("Running EBS archive integration test")
         ebs_test_class = EBSArchiveTestClass()
         backups_engine = ebs_test_class.backups_engine
@@ -107,24 +107,24 @@ class ShelveryEBSArchiveIntegrationTestCase(unittest.TestCase):
         for backup in backups:
             snapshot_id = backup.backup_id
             self.created_snapshots.append(snapshot_id)
-            print(f"Checking archive status for snapshot {snapshot_id}")
-
-            # Wait for snapshot to be available before checking tier
             backups_engine.wait_backup_available(backup.region, snapshot_id, None, None)
 
-            # Allow time for the archive tier transition to be initiated
-            time.sleep(5)
-
-            # Describe the snapshot to check storage tier
             response = client.describe_snapshots(SnapshotIds=[snapshot_id])
             snapshot = response['Snapshots'][0]
+            storage_tier = snapshot.get('StorageTier', 'standard')
+            print(f"Snapshot {snapshot_id} StorageTier after create: {storage_tier}")
+            self.assertEqual(
+                storage_tier,
+                'standard',
+                f"Snapshot {snapshot_id} should remain standard tier until archive_pending_backups runs"
+            )
 
-            # The snapshot should either be archiving or already archived
-            # Note: StorageTier may show 'standard' briefly while archival is in progress,
-            # but describe_snapshot_tier_status should show the tiering status
-            print(f"Snapshot {snapshot_id} StorageTier: {snapshot.get('StorageTier', 'standard')}")
+        backups_engine.archive_pending_backups()
 
-            # Check tiering status via describe_snapshot_tier_status
+        for backup in backups:
+            snapshot_id = backup.backup_id
+            time.sleep(5)
+
             tier_response = client.describe_snapshot_tier_status(
                 Filters=[{'Name': 'snapshot-id', 'Values': [snapshot_id]}]
             )
@@ -132,24 +132,15 @@ class ShelveryEBSArchiveIntegrationTestCase(unittest.TestCase):
             if tier_response.get('SnapshotTierStatuses'):
                 tier_status = tier_response['SnapshotTierStatuses'][0]
                 status = tier_status.get('Status', '')
-                print(f"Tiering status: {status}")
-                print(f"Storage tier: {tier_status.get('StorageTier', 'N/A')}")
-                # The API returns 'archival-in-progress' while archiving,
-                # and 'completed' once the archive operation finishes
+                print(f"Tiering status for {snapshot_id}: {status}")
                 self.assertIn(
                     status,
                     ['archival-in-progress', 'completed'],
                     f"Snapshot {snapshot_id} should be archiving or archived"
                 )
             else:
-                # If the API doesn't return status immediately, the modify call was made
-                # This can happen with very new snapshots
-                print(f"No tier status yet for {snapshot_id} - verifying via retention type")
                 self.assertEqual(backup.retention_type, 'monthly')
 
-        # Cleanup
-        # Note: Snapshots in 'archival-in-progress' state should still be deletable
-        # via the EC2 API. If cleanup fails, orphaned snapshots may need manual removal.
         print("Cleaning up EBS Archive test backups")
         backups_engine.clean_backups()
 
@@ -173,18 +164,17 @@ class ShelveryEBSArchiveIntegrationTestCase(unittest.TestCase):
             self.created_snapshots.append(snapshot_id)
 
             backups_engine.wait_backup_available(backup.region, snapshot_id, None, None)
+            backups_engine.archive_pending_backups()
             time.sleep(5)
 
             response = client.describe_snapshots(SnapshotIds=[snapshot_id])
             snapshot = response['Snapshots'][0]
 
-            # Snapshot should remain in standard tier
             storage_tier = snapshot.get('StorageTier', 'standard')
             print(f"Snapshot {snapshot_id} StorageTier: {storage_tier}")
             self.assertEqual(storage_tier, 'standard',
                              f"Snapshot {snapshot_id} should remain in standard tier when archive is disabled")
 
-        # Cleanup
         print("Cleaning up EBS Archive disabled test backups")
         backups_engine.clean_backups()
 
@@ -209,6 +199,7 @@ class ShelveryEBSArchiveIntegrationTestCase(unittest.TestCase):
             self.created_snapshots.append(snapshot_id)
 
             backups_engine.wait_backup_available(backup.region, snapshot_id, None, None)
+            backups_engine.archive_pending_backups()
             time.sleep(5)
 
             response = client.describe_snapshots(SnapshotIds=[snapshot_id])
@@ -219,14 +210,14 @@ class ShelveryEBSArchiveIntegrationTestCase(unittest.TestCase):
             self.assertEqual(storage_tier, 'standard',
                              f"Daily snapshot {snapshot_id} should NOT be archived")
 
-        # Cleanup
         print("Cleaning up daily backup test")
         backups_engine.clean_backups()
 
     def tearDown(self):
-        # Reset env vars
         os.environ.pop('shelvery_enable_ebs_archive', None)
+        os.environ.pop('shelvery_enable_ebs_archive_pulled', None)
         os.environ.pop('shelvery_current_retention_type', None)
+        os.environ.pop('shelvery_share_aws_account_ids', None)
         print("Waiting 30s due to EBS Snapshot rate limit...")
         time.sleep(30)
 

--- a/shelvery_tests/ebs_integration_test.py
+++ b/shelvery_tests/ebs_integration_test.py
@@ -150,7 +150,19 @@ class ShelveryEBSIntegrationTestCase(unittest.TestCase):
 
         print("Creating shared backups")
         backups = backups_engine.create_backups()
-        print(f"{len(backups)} shared backups created")
+        print(f"First batch: {len(backups)} shared backup(s) created")
+        self.assertGreaterEqual(len(backups), 1, "Expected at least 1 backup from first create_backups()")
+
+        # Destination pull tests need one shared backup each (archive disabled vs enabled).
+        time.sleep(30)  # EBS snapshot create rate limit
+        second_batch = backups_engine.create_backups()
+        print(f"Second batch: {len(second_batch)} shared backup(s) created")
+        backups = backups + second_batch
+        print(f"{len(backups)} shared backups created in total")
+        self.assertGreaterEqual(
+            len(backups), 2,
+            f"Expected 2 shared backups for destination pull tests, got {len(backups)}"
+        )
 
         for backup in backups:
             snapshot_id = backup.backup_id

--- a/shelvery_tests/ebs_integration_test.py
+++ b/shelvery_tests/ebs_integration_test.py
@@ -148,20 +148,27 @@ class ShelveryEBSIntegrationTestCase(unittest.TestCase):
         backups_engine = ebs_test_class.backups_engine
         client = ebs_test_class.client
 
-        print("Creating shared backups")
-        backups = backups_engine.create_backups()
-        print(f"First batch: {len(backups)} shared backup(s) created")
-        self.assertGreaterEqual(len(backups), 1, "Expected at least 1 backup from first create_backups()")
+        print("Creating shared backups (daily + monthly for destination pull test)")
+        os.environ['shelvery_current_retention_type'] = 'daily'
+        daily_backups = backups_engine.create_backups()
+        print(f"Daily batch: {len(daily_backups)} shared backup(s) created")
+        self.assertEqual(len(daily_backups), 1, "Expected 1 daily backup from create_backups()")
 
-        # Destination pull tests need one shared backup each (archive disabled vs enabled).
         time.sleep(30)  # EBS snapshot create rate limit
-        second_batch = backups_engine.create_backups()
-        print(f"Second batch: {len(second_batch)} shared backup(s) created")
-        backups = backups + second_batch
+        os.environ['shelvery_current_retention_type'] = 'monthly'
+        monthly_backups = backups_engine.create_backups()
+        print(f"Monthly batch: {len(monthly_backups)} shared backup(s) created")
+        self.assertEqual(len(monthly_backups), 1, "Expected 1 monthly backup from create_backups()")
+
+        backups = daily_backups + monthly_backups
         print(f"{len(backups)} shared backups created in total")
-        self.assertGreaterEqual(
-            len(backups), 2,
-            f"Expected 2 shared backups for destination pull tests, got {len(backups)}"
+        self.assertEqual(len(backups), 2, f"Expected 2 shared backups (daily + monthly), got {len(backups)}")
+
+        retention_types = {backup.retention_type for backup in backups}
+        self.assertEqual(
+            retention_types,
+            {'daily', 'monthly'},
+            f"Expected daily and monthly retention types, got {retention_types}"
         )
 
         for backup in backups:

--- a/shelvery_tests/ebs_pull_test.py
+++ b/shelvery_tests/ebs_pull_test.py
@@ -22,37 +22,28 @@ class ShelveryEBSPullTestCase(unittest.TestCase):
     
     @pytest.mark.destination
     def test_PullEBSBackup(self):
-
-        # Complete initial setup
-        print(f"EBS - Running pull shared backups test")
+        """Pull shared backups with archive-on-pull disabled (default)."""
+        print("EBS - Running pull shared backups test")
         setup_destination(self)
-    
-        # Create test resource class
+        os.environ.pop('shelvery_enable_ebs_archive_pulled', None)
+
         ebs_test_class = EBSTestClass()
         backups_engine = ebs_test_class.backups_engine
         client = ebs_test_class.client
-        
-        # Clean residual existing snapshots
+
         backups_engine.clean_backups()
 
-        search_filter = [{'Name':'tag:ResourceName',
-                        'Values':[EBS_INSTANCE_RESOURCE_NAME]
-                        }]
+        search_filter = [{'Name': 'tag:ResourceName', 'Values': [EBS_INSTANCE_RESOURCE_NAME]}]
+        pre_pull_count = len(client.describe_snapshots(Filters=search_filter)['Snapshots'])
 
-        # Snapshot count before pull (may include non-stale leftovers from prior runs)
-        pre_pull_count = len(client.describe_snapshots(
-                        Filters=search_filter
-                    )['Snapshots'])
-
-        # Pull shared backups
         backups_engine.pull_shared_backups()
 
-        snapshots = client.describe_snapshots(
-                        Filters=search_filter
-                    )['Snapshots']
-
+        snapshots = client.describe_snapshots(Filters=search_filter)['Snapshots']
         pulled_count = len(snapshots) - pre_pull_count
-        self.assertGreaterEqual(pulled_count, 1, f"Expected at least 1 new snapshot from pull, but got {pulled_count}")
+        self.assertGreaterEqual(
+            pulled_count, 1,
+            f"Expected at least 1 new snapshot from pull, but got {pulled_count}"
+        )
 
     @pytest.mark.destination
     def test_PullEBSBackupWithArchivePulledEnabled(self):

--- a/shelvery_tests/ebs_pull_test.py
+++ b/shelvery_tests/ebs_pull_test.py
@@ -16,6 +16,9 @@ sys.path.append(f"{pwd}/lib")
 sys.path.append(f"{pwd}/../lib")
 
 class ShelveryEBSPullTestCase(unittest.TestCase):
+
+    def tearDown(self):
+        os.environ.pop('shelvery_enable_ebs_archive_pulled', None)
     
     @pytest.mark.destination
     def test_PullEBSBackup(self):
@@ -50,6 +53,31 @@ class ShelveryEBSPullTestCase(unittest.TestCase):
 
         pulled_count = len(snapshots) - pre_pull_count
         self.assertGreaterEqual(pulled_count, 1, f"Expected at least 1 new snapshot from pull, but got {pulled_count}")
+
+    @pytest.mark.destination
+    def test_PullEBSBackupWithArchivePulledEnabled(self):
+        """Pull still succeeds when databunker archive-on-pull is enabled."""
+        print("EBS - Running pull with archive_pulled enabled")
+        setup_destination(self)
+        os.environ['shelvery_enable_ebs_archive_pulled'] = 'true'
+
+        ebs_test_class = EBSTestClass()
+        backups_engine = ebs_test_class.backups_engine
+        client = ebs_test_class.client
+
+        backups_engine.clean_backups()
+
+        search_filter = [{'Name': 'tag:ResourceName', 'Values': [EBS_INSTANCE_RESOURCE_NAME]}]
+        pre_pull_count = len(client.describe_snapshots(Filters=search_filter)['Snapshots'])
+
+        backups_engine.pull_shared_backups()
+
+        snapshots = client.describe_snapshots(Filters=search_filter)['Snapshots']
+        pulled_count = len(snapshots) - pre_pull_count
+        self.assertGreaterEqual(
+            pulled_count, 1,
+            f"Expected at least 1 new snapshot from pull with archive_pulled enabled, got {pulled_count}"
+        )
     
     @pytest.mark.cleanup
     def test_cleanup(self):

--- a/shelvery_tests/ebs_pull_test.py
+++ b/shelvery_tests/ebs_pull_test.py
@@ -3,8 +3,14 @@ import unittest
 import os
 import pytest
 from shelvery_tests.ebs_integration_test import EBSTestClass
-from shelvery_tests.test_functions import setup_destination
+from shelvery_tests.test_functions import (
+    setup_destination,
+    group_snapshots_by_retention_type,
+    assert_snapshot_is_standard,
+    assert_snapshot_is_archived_or_archiving,
+)
 from shelvery_tests.resources import EBS_INSTANCE_RESOURCE_NAME
+from shelvery.backup_resource import BackupResource
 
 
 pwd = os.path.dirname(os.path.abspath(__file__))
@@ -19,36 +25,11 @@ class ShelveryEBSPullTestCase(unittest.TestCase):
 
     def tearDown(self):
         os.environ.pop('shelvery_enable_ebs_archive_pulled', None)
-    
-    @pytest.mark.destination
-    def test_PullEBSBackup(self):
-        """Pull shared backups with archive-on-pull disabled (default)."""
-        print("EBS - Running pull shared backups test")
-        setup_destination(self)
-        os.environ.pop('shelvery_enable_ebs_archive_pulled', None)
-
-        ebs_test_class = EBSTestClass()
-        backups_engine = ebs_test_class.backups_engine
-        client = ebs_test_class.client
-
-        backups_engine.clean_backups()
-
-        search_filter = [{'Name': 'tag:ResourceName', 'Values': [EBS_INSTANCE_RESOURCE_NAME]}]
-        pre_pull_count = len(client.describe_snapshots(Filters=search_filter)['Snapshots'])
-
-        backups_engine.pull_shared_backups()
-
-        snapshots = client.describe_snapshots(Filters=search_filter)['Snapshots']
-        pulled_count = len(snapshots) - pre_pull_count
-        self.assertGreaterEqual(
-            pulled_count, 1,
-            f"Expected at least 1 new snapshot from pull, but got {pulled_count}"
-        )
 
     @pytest.mark.destination
     def test_PullEBSBackupWithArchivePulledEnabled(self):
-        """Pull still succeeds when databunker archive-on-pull is enabled."""
-        print("EBS - Running pull with archive_pulled enabled")
+        """Pull daily + monthly shared backups; only monthly is archived when enabled."""
+        print("EBS - Running pull with archive_pulled enabled (daily + monthly)")
         setup_destination(self)
         os.environ['shelvery_enable_ebs_archive_pulled'] = 'true'
 
@@ -59,17 +40,39 @@ class ShelveryEBSPullTestCase(unittest.TestCase):
         backups_engine.clean_backups()
 
         search_filter = [{'Name': 'tag:ResourceName', 'Values': [EBS_INSTANCE_RESOURCE_NAME]}]
-        pre_pull_count = len(client.describe_snapshots(Filters=search_filter)['Snapshots'])
+        pre_pull_snapshots = client.describe_snapshots(Filters=search_filter)['Snapshots']
+        pre_pull_ids = {snapshot['SnapshotId'] for snapshot in pre_pull_snapshots}
 
         backups_engine.pull_shared_backups()
 
-        snapshots = client.describe_snapshots(Filters=search_filter)['Snapshots']
-        pulled_count = len(snapshots) - pre_pull_count
-        self.assertGreaterEqual(
-            pulled_count, 1,
-            f"Expected at least 1 new snapshot from pull with archive_pulled enabled, got {pulled_count}"
+        post_pull_snapshots = client.describe_snapshots(Filters=search_filter)['Snapshots']
+        pulled_snapshots = [
+            snapshot for snapshot in post_pull_snapshots
+            if snapshot['SnapshotId'] not in pre_pull_ids
+        ]
+        self.assertEqual(
+            len(pulled_snapshots), 2,
+            f"Expected exactly 2 new snapshots from pull (daily + monthly), got {len(pulled_snapshots)}"
         )
-    
+
+        by_retention = group_snapshots_by_retention_type(pulled_snapshots)
+        self.assertIn(BackupResource.RETENTION_DAILY, by_retention)
+        self.assertIn(BackupResource.RETENTION_MONTHLY, by_retention)
+
+        for snapshot in pulled_snapshots:
+            backups_engine.wait_backup_available(
+                backups_engine.region,
+                snapshot['SnapshotId'],
+                None,
+                None,
+            )
+
+        daily_snapshot = by_retention[BackupResource.RETENTION_DAILY][0]
+        monthly_snapshot = by_retention[BackupResource.RETENTION_MONTHLY][0]
+
+        assert_snapshot_is_standard(self, client, daily_snapshot['SnapshotId'])
+        assert_snapshot_is_archived_or_archiving(self, client, monthly_snapshot['SnapshotId'])
+
     @pytest.mark.cleanup
     def test_cleanup(self):
         # Create test resource class

--- a/shelvery_tests/ebs_pull_test.py
+++ b/shelvery_tests/ebs_pull_test.py
@@ -32,21 +32,24 @@ class ShelveryEBSPullTestCase(unittest.TestCase):
         # Clean residual existing snapshots
         backups_engine.clean_backups()
 
-        # Pull shared backups
-        backups_engine.pull_shared_backups()
-
-        # Get post-pull snapshot count
         search_filter = [{'Name':'tag:ResourceName',
                         'Values':[EBS_INSTANCE_RESOURCE_NAME]
                         }]
-                                  
-        #Retrieve pulled images from shelvery-test stack
+
+        # Snapshot count before pull (may include non-stale leftovers from prior runs)
+        pre_pull_count = len(client.describe_snapshots(
+                        Filters=search_filter
+                    )['Snapshots'])
+
+        # Pull shared backups
+        backups_engine.pull_shared_backups()
+
         snapshots = client.describe_snapshots(
                         Filters=search_filter
                     )['Snapshots']
 
-        # Verify that only one snapshot was pulled
-        self.assertEqual(len(snapshots), 1)
+        pulled_count = len(snapshots) - pre_pull_count
+        self.assertGreaterEqual(pulled_count, 1, f"Expected at least 1 new snapshot from pull, but got {pulled_count}")
     
     @pytest.mark.cleanup
     def test_cleanup(self):

--- a/shelvery_tests/test_functions.py
+++ b/shelvery_tests/test_functions.py
@@ -69,3 +69,56 @@ def compare_backups(self,backup,backup_engine):
         )
     
     return True
+
+
+def snapshot_retention_type(snapshot: dict) -> str:
+    """Return shelvery retention_type from EC2 snapshot tags."""
+    tag_prefix = RuntimeConfig.get_tag_prefix()
+    tags = {tag['Key']: tag['Value'] for tag in snapshot.get('Tags', [])}
+    return tags.get(f"{tag_prefix}:retention_type", '')
+
+
+def group_snapshots_by_retention_type(snapshots: list) -> dict:
+    """Group describe_snapshots results by shelvery retention_type tag."""
+    grouped = {}
+    for snapshot in snapshots:
+        retention_type = snapshot_retention_type(snapshot)
+        grouped.setdefault(retention_type, []).append(snapshot)
+    return grouped
+
+
+def assert_snapshot_is_standard(test_case, client, snapshot_id: str) -> None:
+    """Assert an EBS snapshot remains on the standard storage tier."""
+    response = client.describe_snapshots(SnapshotIds=[snapshot_id])
+    storage_tier = response['Snapshots'][0].get('StorageTier', 'standard')
+    test_case.assertEqual(
+        storage_tier,
+        'standard',
+        f"Snapshot {snapshot_id} should remain standard tier, got {storage_tier}"
+    )
+
+
+def assert_snapshot_is_archived_or_archiving(test_case, client, snapshot_id: str) -> None:
+    """Assert an EBS snapshot is archived or archival is in progress."""
+    time.sleep(5)
+    snapshot = client.describe_snapshots(SnapshotIds=[snapshot_id])['Snapshots'][0]
+    storage_tier = snapshot.get('StorageTier', 'standard')
+    if storage_tier == 'archive':
+        return
+
+    tier_response = client.describe_snapshot_tier_status(
+        Filters=[{'Name': 'snapshot-id', 'Values': [snapshot_id]}]
+    )
+    if tier_response.get('SnapshotTierStatuses'):
+        status = tier_response['SnapshotTierStatuses'][0].get('Status', '')
+        test_case.assertIn(
+            status,
+            ['archival-in-progress', 'completed'],
+            f"Snapshot {snapshot_id} should be archiving or archived, got status {status!r}"
+        )
+        return
+
+    test_case.fail(
+        f"Snapshot {snapshot_id} expected archive tier or tiering status, "
+        f"got StorageTier={storage_tier!r}"
+    )

--- a/shelvery_tests/unit/conftest.py
+++ b/shelvery_tests/unit/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup(request):
+    """Override the parent conftest setup fixture for unit tests (no AWS needed)."""
+    pass

--- a/shelvery_tests/unit/ebs_archive_unit_test.py
+++ b/shelvery_tests/unit/ebs_archive_unit_test.py
@@ -1,0 +1,256 @@
+import unittest
+import sys
+import os
+from unittest.mock import patch, MagicMock
+from datetime import datetime
+
+pwd = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(f"{pwd}/..")
+sys.path.append(f"{pwd}/../shelvery")
+sys.path.append(f"{pwd}/shelvery")
+sys.path.append(f"{pwd}/lib")
+sys.path.append(f"{pwd}/../lib")
+
+from shelvery.ebs_backup import ShelveryEBSBackup
+from shelvery.backup_resource import BackupResource
+from shelvery.entity_resource import EntityResource
+from shelvery.runtime_config import RuntimeConfig
+
+
+class ShelveryEBSArchiveUnitTest(unittest.TestCase):
+    """Unit tests for EBS Snapshots Archive tier feature"""
+
+    def _make_backup_resource(self, retention_type, snapshot_id='snap-12345'):
+        """Helper to create a mock BackupResource with given retention type."""
+        br = MagicMock(spec=BackupResource)
+        br.backup_id = snapshot_id
+        br.retention_type = retention_type
+        br.entity_resource = MagicMock(spec=EntityResource)
+        br.entity_resource.tags = {}
+        return br
+
+    @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'true'}, clear=False)
+    def test_get_enable_ebs_archive_true(self):
+        """Config accessor returns True when env var is 'true'."""
+        engine = MagicMock()
+        engine.lambda_payload = None
+        result = RuntimeConfig.get_enable_ebs_archive(None, engine)
+        self.assertTrue(result)
+
+    @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'false'}, clear=False)
+    def test_get_enable_ebs_archive_false(self):
+        """Config accessor returns False when env var is 'false'."""
+        engine = MagicMock()
+        engine.lambda_payload = None
+        result = RuntimeConfig.get_enable_ebs_archive(None, engine)
+        self.assertFalse(result)
+
+    @patch.dict(os.environ, {}, clear=False)
+    def test_get_enable_ebs_archive_default(self):
+        """Config accessor returns False when not set (uses default)."""
+        os.environ.pop('shelvery_enable_ebs_archive', None)
+        engine = MagicMock()
+        engine.lambda_payload = None
+        result = RuntimeConfig.get_enable_ebs_archive(None, engine)
+        self.assertFalse(result)
+
+    def test_get_enable_ebs_archive_from_resource_tags(self):
+        """Config accessor reads from resource tags with highest priority."""
+        engine = MagicMock()
+        engine.lambda_payload = None
+        tags = {'shelvery:config:shelvery_enable_ebs_archive': 'true'}
+        result = RuntimeConfig.get_enable_ebs_archive(tags, engine)
+        self.assertTrue(result)
+
+    @patch('shelvery.ebs_backup.AwsHelper')
+    def test_archive_backup_calls_modify_snapshot_tier(self, mock_aws_helper):
+        """archive_backup calls ec2 modify_snapshot_tier with correct params."""
+        mock_client = MagicMock()
+        mock_aws_helper.boto3_client.return_value = mock_client
+
+        engine = ShelveryEBSBackup.__new__(ShelveryEBSBackup)
+        engine.role_arn = None
+        engine.role_external_id = None
+        engine.logger = MagicMock()
+
+        br = self._make_backup_resource(BackupResource.RETENTION_MONTHLY, 'snap-abc123')
+
+        engine.archive_backup(br)
+
+        mock_client.modify_snapshot_tier.assert_called_once_with(
+            SnapshotId='snap-abc123',
+            StorageTier='archive'
+        )
+
+    @patch('shelvery.ebs_backup.AwsHelper')
+    @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'true'}, clear=False)
+    def test_post_create_backups_archives_monthly(self, mock_aws_helper):
+        """post_create_backups archives monthly backups when feature enabled."""
+        mock_client = MagicMock()
+        mock_aws_helper.boto3_client.return_value = mock_client
+
+        engine = ShelveryEBSBackup.__new__(ShelveryEBSBackup)
+        engine.role_arn = None
+        engine.role_external_id = None
+        engine.logger = MagicMock()
+        engine.lambda_payload = None
+
+        monthly_br = self._make_backup_resource(BackupResource.RETENTION_MONTHLY, 'snap-monthly')
+
+        engine.post_create_backups([monthly_br])
+
+        mock_client.modify_snapshot_tier.assert_called_once_with(
+            SnapshotId='snap-monthly',
+            StorageTier='archive'
+        )
+
+    @patch('shelvery.ebs_backup.AwsHelper')
+    @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'true'}, clear=False)
+    def test_post_create_backups_archives_yearly(self, mock_aws_helper):
+        """post_create_backups archives yearly backups when feature enabled."""
+        mock_client = MagicMock()
+        mock_aws_helper.boto3_client.return_value = mock_client
+
+        engine = ShelveryEBSBackup.__new__(ShelveryEBSBackup)
+        engine.role_arn = None
+        engine.role_external_id = None
+        engine.logger = MagicMock()
+        engine.lambda_payload = None
+
+        yearly_br = self._make_backup_resource(BackupResource.RETENTION_YEARLY, 'snap-yearly')
+
+        engine.post_create_backups([yearly_br])
+
+        mock_client.modify_snapshot_tier.assert_called_once_with(
+            SnapshotId='snap-yearly',
+            StorageTier='archive'
+        )
+
+    @patch('shelvery.ebs_backup.AwsHelper')
+    @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'true'}, clear=False)
+    def test_post_create_backups_skips_daily(self, mock_aws_helper):
+        """post_create_backups does NOT archive daily backups."""
+        mock_client = MagicMock()
+        mock_aws_helper.boto3_client.return_value = mock_client
+
+        engine = ShelveryEBSBackup.__new__(ShelveryEBSBackup)
+        engine.role_arn = None
+        engine.role_external_id = None
+        engine.logger = MagicMock()
+        engine.lambda_payload = None
+
+        daily_br = self._make_backup_resource(BackupResource.RETENTION_DAILY, 'snap-daily')
+
+        engine.post_create_backups([daily_br])
+
+        mock_client.modify_snapshot_tier.assert_not_called()
+
+    @patch('shelvery.ebs_backup.AwsHelper')
+    @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'true'}, clear=False)
+    def test_post_create_backups_skips_weekly(self, mock_aws_helper):
+        """post_create_backups does NOT archive weekly backups."""
+        mock_client = MagicMock()
+        mock_aws_helper.boto3_client.return_value = mock_client
+
+        engine = ShelveryEBSBackup.__new__(ShelveryEBSBackup)
+        engine.role_arn = None
+        engine.role_external_id = None
+        engine.logger = MagicMock()
+        engine.lambda_payload = None
+
+        weekly_br = self._make_backup_resource(BackupResource.RETENTION_WEEKLY, 'snap-weekly')
+
+        engine.post_create_backups([weekly_br])
+
+        mock_client.modify_snapshot_tier.assert_not_called()
+
+    @patch('shelvery.ebs_backup.AwsHelper')
+    @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'false'}, clear=False)
+    def test_post_create_backups_disabled_skips_monthly(self, mock_aws_helper):
+        """post_create_backups does NOT archive when feature is disabled."""
+        mock_client = MagicMock()
+        mock_aws_helper.boto3_client.return_value = mock_client
+
+        engine = ShelveryEBSBackup.__new__(ShelveryEBSBackup)
+        engine.role_arn = None
+        engine.role_external_id = None
+        engine.logger = MagicMock()
+        engine.lambda_payload = None
+
+        monthly_br = self._make_backup_resource(BackupResource.RETENTION_MONTHLY, 'snap-monthly')
+
+        engine.post_create_backups([monthly_br])
+
+        mock_client.modify_snapshot_tier.assert_not_called()
+
+    @patch('shelvery.ebs_backup.AwsHelper')
+    @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'true'}, clear=False)
+    def test_post_create_backups_mixed_retention_types(self, mock_aws_helper):
+        """post_create_backups only archives monthly/yearly from a mixed list."""
+        mock_client = MagicMock()
+        mock_aws_helper.boto3_client.return_value = mock_client
+
+        engine = ShelveryEBSBackup.__new__(ShelveryEBSBackup)
+        engine.role_arn = None
+        engine.role_external_id = None
+        engine.logger = MagicMock()
+        engine.lambda_payload = None
+
+        daily_br = self._make_backup_resource(BackupResource.RETENTION_DAILY, 'snap-daily')
+        weekly_br = self._make_backup_resource(BackupResource.RETENTION_WEEKLY, 'snap-weekly')
+        monthly_br = self._make_backup_resource(BackupResource.RETENTION_MONTHLY, 'snap-monthly')
+        yearly_br = self._make_backup_resource(BackupResource.RETENTION_YEARLY, 'snap-yearly')
+
+        engine.post_create_backups([daily_br, weekly_br, monthly_br, yearly_br])
+
+        calls = mock_client.modify_snapshot_tier.call_args_list
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0].kwargs['SnapshotId'], 'snap-monthly')
+        self.assertEqual(calls[1].kwargs['SnapshotId'], 'snap-yearly')
+
+    @patch('shelvery.ebs_backup.AwsHelper')
+    @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'true'}, clear=False)
+    def test_post_create_backups_handles_api_error_gracefully(self, mock_aws_helper):
+        """post_create_backups logs but does not raise on archive failure."""
+        mock_client = MagicMock()
+        mock_client.modify_snapshot_tier.side_effect = Exception("API Error")
+        mock_aws_helper.boto3_client.return_value = mock_client
+
+        engine = ShelveryEBSBackup.__new__(ShelveryEBSBackup)
+        engine.role_arn = None
+        engine.role_external_id = None
+        engine.logger = MagicMock()
+        engine.lambda_payload = None
+
+        monthly_br = self._make_backup_resource(BackupResource.RETENTION_MONTHLY, 'snap-fail')
+
+        # Should not raise
+        engine.post_create_backups([monthly_br])
+
+        engine.logger.exception.assert_called_once()
+
+    @patch('shelvery.ebs_backup.AwsHelper')
+    @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'true'}, clear=False)
+    def test_post_create_backups_per_resource_tag_override(self, mock_aws_helper):
+        """Archive is skipped for a resource that has the tag set to false."""
+        mock_client = MagicMock()
+        mock_aws_helper.boto3_client.return_value = mock_client
+
+        engine = ShelveryEBSBackup.__new__(ShelveryEBSBackup)
+        engine.role_arn = None
+        engine.role_external_id = None
+        engine.logger = MagicMock()
+        engine.lambda_payload = None
+
+        monthly_br = self._make_backup_resource(BackupResource.RETENTION_MONTHLY, 'snap-override')
+        monthly_br.entity_resource.tags = {
+            'shelvery:config:shelvery_enable_ebs_archive': 'false'
+        }
+
+        engine.post_create_backups([monthly_br])
+
+        mock_client.modify_snapshot_tier.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/shelvery_tests/unit/ebs_archive_unit_test.py
+++ b/shelvery_tests/unit/ebs_archive_unit_test.py
@@ -25,6 +25,7 @@ class ShelveryEBSArchiveUnitTest(unittest.TestCase):
         br = MagicMock(spec=BackupResource)
         br.backup_id = snapshot_id
         br.retention_type = retention_type
+        br.region = 'ap-southeast-2'
         br.entity_resource = MagicMock(spec=EntityResource)
         br.entity_resource.tags = {}
         return br
@@ -94,11 +95,13 @@ class ShelveryEBSArchiveUnitTest(unittest.TestCase):
         engine.role_external_id = None
         engine.logger = MagicMock()
         engine.lambda_payload = None
+        engine.wait_backup_available = MagicMock(return_value=True)
 
         monthly_br = self._make_backup_resource(BackupResource.RETENTION_MONTHLY, 'snap-monthly')
 
         engine.post_create_backups([monthly_br])
 
+        engine.wait_backup_available.assert_called_once_with('ap-southeast-2', 'snap-monthly', None, None)
         mock_client.modify_snapshot_tier.assert_called_once_with(
             SnapshotId='snap-monthly',
             StorageTier='archive'
@@ -116,11 +119,13 @@ class ShelveryEBSArchiveUnitTest(unittest.TestCase):
         engine.role_external_id = None
         engine.logger = MagicMock()
         engine.lambda_payload = None
+        engine.wait_backup_available = MagicMock(return_value=True)
 
         yearly_br = self._make_backup_resource(BackupResource.RETENTION_YEARLY, 'snap-yearly')
 
         engine.post_create_backups([yearly_br])
 
+        engine.wait_backup_available.assert_called_once_with('ap-southeast-2', 'snap-yearly', None, None)
         mock_client.modify_snapshot_tier.assert_called_once_with(
             SnapshotId='snap-yearly',
             StorageTier='archive'
@@ -138,11 +143,13 @@ class ShelveryEBSArchiveUnitTest(unittest.TestCase):
         engine.role_external_id = None
         engine.logger = MagicMock()
         engine.lambda_payload = None
+        engine.wait_backup_available = MagicMock(return_value=True)
 
         daily_br = self._make_backup_resource(BackupResource.RETENTION_DAILY, 'snap-daily')
 
         engine.post_create_backups([daily_br])
 
+        engine.wait_backup_available.assert_not_called()
         mock_client.modify_snapshot_tier.assert_not_called()
 
     @patch('shelvery.ebs_backup.AwsHelper')
@@ -157,11 +164,13 @@ class ShelveryEBSArchiveUnitTest(unittest.TestCase):
         engine.role_external_id = None
         engine.logger = MagicMock()
         engine.lambda_payload = None
+        engine.wait_backup_available = MagicMock(return_value=True)
 
         weekly_br = self._make_backup_resource(BackupResource.RETENTION_WEEKLY, 'snap-weekly')
 
         engine.post_create_backups([weekly_br])
 
+        engine.wait_backup_available.assert_not_called()
         mock_client.modify_snapshot_tier.assert_not_called()
 
     @patch('shelvery.ebs_backup.AwsHelper')
@@ -176,11 +185,13 @@ class ShelveryEBSArchiveUnitTest(unittest.TestCase):
         engine.role_external_id = None
         engine.logger = MagicMock()
         engine.lambda_payload = None
+        engine.wait_backup_available = MagicMock(return_value=True)
 
         monthly_br = self._make_backup_resource(BackupResource.RETENTION_MONTHLY, 'snap-monthly')
 
         engine.post_create_backups([monthly_br])
 
+        engine.wait_backup_available.assert_not_called()
         mock_client.modify_snapshot_tier.assert_not_called()
 
     @patch('shelvery.ebs_backup.AwsHelper')
@@ -195,6 +206,7 @@ class ShelveryEBSArchiveUnitTest(unittest.TestCase):
         engine.role_external_id = None
         engine.logger = MagicMock()
         engine.lambda_payload = None
+        engine.wait_backup_available = MagicMock(return_value=True)
 
         daily_br = self._make_backup_resource(BackupResource.RETENTION_DAILY, 'snap-daily')
         weekly_br = self._make_backup_resource(BackupResource.RETENTION_WEEKLY, 'snap-weekly')
@@ -203,6 +215,7 @@ class ShelveryEBSArchiveUnitTest(unittest.TestCase):
 
         engine.post_create_backups([daily_br, weekly_br, monthly_br, yearly_br])
 
+        self.assertEqual(engine.wait_backup_available.call_count, 2)
         calls = mock_client.modify_snapshot_tier.call_args_list
         self.assertEqual(len(calls), 2)
         self.assertEqual(calls[0].kwargs['SnapshotId'], 'snap-monthly')
@@ -221,6 +234,7 @@ class ShelveryEBSArchiveUnitTest(unittest.TestCase):
         engine.role_external_id = None
         engine.logger = MagicMock()
         engine.lambda_payload = None
+        engine.wait_backup_available = MagicMock(return_value=True)
 
         monthly_br = self._make_backup_resource(BackupResource.RETENTION_MONTHLY, 'snap-fail')
 
@@ -241,6 +255,7 @@ class ShelveryEBSArchiveUnitTest(unittest.TestCase):
         engine.role_external_id = None
         engine.logger = MagicMock()
         engine.lambda_payload = None
+        engine.wait_backup_available = MagicMock(return_value=True)
 
         monthly_br = self._make_backup_resource(BackupResource.RETENTION_MONTHLY, 'snap-override')
         monthly_br.entity_resource.tags = {
@@ -249,6 +264,7 @@ class ShelveryEBSArchiveUnitTest(unittest.TestCase):
 
         engine.post_create_backups([monthly_br])
 
+        engine.wait_backup_available.assert_not_called()
         mock_client.modify_snapshot_tier.assert_not_called()
 
 

--- a/shelvery_tests/unit/ebs_archive_unit_test.py
+++ b/shelvery_tests/unit/ebs_archive_unit_test.py
@@ -1,8 +1,8 @@
 import unittest
 import sys
 import os
-from unittest.mock import patch, MagicMock
-from datetime import datetime
+from unittest.mock import patch, MagicMock, call
+from botocore.exceptions import ClientError
 
 pwd = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(f"{pwd}/..")
@@ -17,63 +17,75 @@ from shelvery.entity_resource import EntityResource
 from shelvery.runtime_config import RuntimeConfig
 
 
+def head_object_not_found(*args, **kwargs):
+    raise ClientError({'Error': {'Code': '404'}}, 'HeadObject')
+
+
 class ShelveryEBSArchiveUnitTest(unittest.TestCase):
     """Unit tests for EBS Snapshots Archive tier feature"""
 
-    def _make_backup_resource(self, retention_type, snapshot_id='snap-12345'):
-        """Helper to create a mock BackupResource with given retention type."""
-        br = MagicMock(spec=BackupResource)
-        br.backup_id = snapshot_id
-        br.retention_type = retention_type
-        br.region = 'ap-southeast-2'
-        br.entity_resource = MagicMock(spec=EntityResource)
-        br.entity_resource.tags = {}
-        return br
-
-    @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'true'}, clear=False)
-    def test_get_enable_ebs_archive_true(self):
-        """Config accessor returns True when env var is 'true'."""
-        engine = MagicMock()
-        engine.lambda_payload = None
-        result = RuntimeConfig.get_enable_ebs_archive(None, engine)
-        self.assertTrue(result)
-
-    @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'false'}, clear=False)
-    def test_get_enable_ebs_archive_false(self):
-        """Config accessor returns False when env var is 'false'."""
-        engine = MagicMock()
-        engine.lambda_payload = None
-        result = RuntimeConfig.get_enable_ebs_archive(None, engine)
-        self.assertFalse(result)
-
-    @patch.dict(os.environ, {}, clear=False)
-    def test_get_enable_ebs_archive_default(self):
-        """Config accessor returns False when not set (uses default)."""
-        os.environ.pop('shelvery_enable_ebs_archive', None)
-        engine = MagicMock()
-        engine.lambda_payload = None
-        result = RuntimeConfig.get_enable_ebs_archive(None, engine)
-        self.assertFalse(result)
-
-    def test_get_enable_ebs_archive_from_resource_tags(self):
-        """Config accessor reads from resource tags with highest priority."""
-        engine = MagicMock()
-        engine.lambda_payload = None
-        tags = {'shelvery:config:shelvery_enable_ebs_archive': 'true'}
-        result = RuntimeConfig.get_enable_ebs_archive(tags, engine)
-        self.assertTrue(result)
-
-    @patch('shelvery.ebs_backup.AwsHelper')
-    def test_archive_backup_calls_modify_snapshot_tier(self, mock_aws_helper):
-        """archive_backup calls ec2 modify_snapshot_tier with correct params."""
-        mock_client = MagicMock()
-        mock_aws_helper.boto3_client.return_value = mock_client
-
+    def _make_engine(self):
         engine = ShelveryEBSBackup.__new__(ShelveryEBSBackup)
         engine.role_arn = None
         engine.role_external_id = None
         engine.logger = MagicMock()
+        engine.lambda_payload = None
+        engine.account_id = '111111111111'
+        engine.region = 'ap-southeast-2'
+        return engine
 
+    def _make_backup_resource(self, retention_type, snapshot_id='snap-12345', tags=None):
+        br = MagicMock(spec=BackupResource)
+        br.backup_id = snapshot_id
+        br.retention_type = retention_type
+        br.region = 'ap-southeast-2'
+        br.name = f'test-backup-{retention_type}'
+        br.entity_resource = MagicMock(spec=EntityResource)
+        br.entity_resource.tags = tags or {}
+        br.tags = {
+            'shelvery:tag_name': 'shelvery',
+            'shelvery:retention_type': retention_type,
+            'shelvery:name': br.name,
+        }
+        br.entity_resource_tags = MagicMock(return_value=tags or {})
+        return br
+
+    @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'true'}, clear=False)
+    def test_get_enable_ebs_archive_true(self):
+        engine = MagicMock()
+        engine.lambda_payload = None
+        self.assertTrue(RuntimeConfig.get_enable_ebs_archive(None, engine))
+
+    @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'false'}, clear=False)
+    def test_get_enable_ebs_archive_false(self):
+        engine = MagicMock()
+        engine.lambda_payload = None
+        self.assertFalse(RuntimeConfig.get_enable_ebs_archive(None, engine))
+
+    @patch.dict(os.environ, {}, clear=False)
+    def test_get_enable_ebs_archive_default(self):
+        os.environ.pop('shelvery_enable_ebs_archive', None)
+        engine = MagicMock()
+        engine.lambda_payload = None
+        self.assertFalse(RuntimeConfig.get_enable_ebs_archive(None, engine))
+
+    @patch.dict(os.environ, {'shelvery_enable_ebs_archive_pulled': 'true'}, clear=False)
+    def test_get_enable_ebs_archive_pulled_true(self):
+        engine = MagicMock()
+        engine.lambda_payload = None
+        self.assertTrue(RuntimeConfig.get_enable_ebs_archive_pulled(None, engine))
+
+    def test_get_enable_ebs_archive_from_resource_tags(self):
+        engine = MagicMock()
+        engine.lambda_payload = None
+        tags = {'shelvery:config:shelvery_enable_ebs_archive': 'true'}
+        self.assertTrue(RuntimeConfig.get_enable_ebs_archive(tags, engine))
+
+    @patch('shelvery.ebs_backup.AwsHelper')
+    def test_archive_backup_calls_modify_snapshot_tier(self, mock_aws_helper):
+        mock_client = MagicMock()
+        mock_aws_helper.boto3_client.return_value = mock_client
+        engine = self._make_engine()
         br = self._make_backup_resource(BackupResource.RETENTION_MONTHLY, 'snap-abc123')
 
         engine.archive_backup(br)
@@ -84,22 +96,15 @@ class ShelveryEBSArchiveUnitTest(unittest.TestCase):
         )
 
     @patch('shelvery.ebs_backup.AwsHelper')
-    @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'true'}, clear=False)
-    def test_post_create_backups_archives_monthly(self, mock_aws_helper):
-        """post_create_backups archives monthly backups when feature enabled."""
+    @patch.dict(os.environ, {'shelvery_enable_ebs_archive_pulled': 'true'}, clear=False)
+    def test_post_pull_backups_archives_monthly(self, mock_aws_helper):
         mock_client = MagicMock()
         mock_aws_helper.boto3_client.return_value = mock_client
-
-        engine = ShelveryEBSBackup.__new__(ShelveryEBSBackup)
-        engine.role_arn = None
-        engine.role_external_id = None
-        engine.logger = MagicMock()
-        engine.lambda_payload = None
+        engine = self._make_engine()
         engine.wait_backup_available = MagicMock(return_value=True)
-
         monthly_br = self._make_backup_resource(BackupResource.RETENTION_MONTHLY, 'snap-monthly')
 
-        engine.post_create_backups([monthly_br])
+        engine.post_pull_backups([monthly_br])
 
         engine.wait_backup_available.assert_called_once_with('ap-southeast-2', 'snap-monthly', None, None)
         mock_client.modify_snapshot_tier.assert_called_once_with(
@@ -108,164 +113,183 @@ class ShelveryEBSArchiveUnitTest(unittest.TestCase):
         )
 
     @patch('shelvery.ebs_backup.AwsHelper')
-    @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'true'}, clear=False)
-    def test_post_create_backups_archives_yearly(self, mock_aws_helper):
-        """post_create_backups archives yearly backups when feature enabled."""
+    @patch.dict(os.environ, {'shelvery_enable_ebs_archive_pulled': 'true'}, clear=False)
+    def test_post_pull_backups_skips_daily(self, mock_aws_helper):
         mock_client = MagicMock()
         mock_aws_helper.boto3_client.return_value = mock_client
-
-        engine = ShelveryEBSBackup.__new__(ShelveryEBSBackup)
-        engine.role_arn = None
-        engine.role_external_id = None
-        engine.logger = MagicMock()
-        engine.lambda_payload = None
+        engine = self._make_engine()
         engine.wait_backup_available = MagicMock(return_value=True)
+        daily_br = self._make_backup_resource(BackupResource.RETENTION_DAILY, 'snap-daily')
 
-        yearly_br = self._make_backup_resource(BackupResource.RETENTION_YEARLY, 'snap-yearly')
+        engine.post_pull_backups([daily_br])
 
-        engine.post_create_backups([yearly_br])
+        engine.wait_backup_available.assert_not_called()
+        mock_client.modify_snapshot_tier.assert_not_called()
 
-        engine.wait_backup_available.assert_called_once_with('ap-southeast-2', 'snap-yearly', None, None)
+    @patch('shelvery.ebs_backup.AwsHelper')
+    @patch.dict(os.environ, {'shelvery_enable_ebs_archive_pulled': 'false'}, clear=False)
+    def test_post_pull_backups_disabled_skips_monthly(self, mock_aws_helper):
+        mock_client = MagicMock()
+        mock_aws_helper.boto3_client.return_value = mock_client
+        engine = self._make_engine()
+        engine.wait_backup_available = MagicMock(return_value=True)
+        monthly_br = self._make_backup_resource(BackupResource.RETENTION_MONTHLY, 'snap-monthly')
+
+        engine.post_pull_backups([monthly_br])
+
+        engine.wait_backup_available.assert_not_called()
+        mock_client.modify_snapshot_tier.assert_not_called()
+
+    @patch('shelvery.ebs_backup.RuntimeConfig.get_share_with_accounts', return_value=[])
+    @patch('shelvery.ebs_backup.AwsHelper')
+    @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'true'}, clear=False)
+    def test_archive_pending_backups_standalone_archives_monthly(
+        self, mock_aws_helper, mock_share_accounts
+    ):
+        mock_client = MagicMock()
+        mock_client.describe_snapshots.return_value = {
+            'Snapshots': [{'StorageTier': 'standard', 'State': 'completed', 'Progress': '100%'}]
+        }
+        mock_aws_helper.boto3_client.return_value = mock_client
+        engine = self._make_engine()
+        engine.wait_backup_available = MagicMock(return_value=True)
+        monthly_br = self._make_backup_resource(BackupResource.RETENTION_MONTHLY, 'snap-monthly')
+
+        with patch.object(ShelveryEBSBackup, 'get_existing_backups', return_value=[monthly_br]):
+            engine.archive_pending_backups()
+
         mock_client.modify_snapshot_tier.assert_called_once_with(
-            SnapshotId='snap-yearly',
+            SnapshotId='snap-monthly',
             StorageTier='archive'
         )
 
     @patch('shelvery.ebs_backup.AwsHelper')
-    @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'true'}, clear=False)
-    def test_post_create_backups_skips_daily(self, mock_aws_helper):
-        """post_create_backups does NOT archive daily backups."""
-        mock_client = MagicMock()
-        mock_aws_helper.boto3_client.return_value = mock_client
-
-        engine = ShelveryEBSBackup.__new__(ShelveryEBSBackup)
-        engine.role_arn = None
-        engine.role_external_id = None
-        engine.logger = MagicMock()
-        engine.lambda_payload = None
-        engine.wait_backup_available = MagicMock(return_value=True)
-
-        daily_br = self._make_backup_resource(BackupResource.RETENTION_DAILY, 'snap-daily')
-
-        engine.post_create_backups([daily_br])
-
-        engine.wait_backup_available.assert_not_called()
-        mock_client.modify_snapshot_tier.assert_not_called()
-
-    @patch('shelvery.ebs_backup.AwsHelper')
-    @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'true'}, clear=False)
-    def test_post_create_backups_skips_weekly(self, mock_aws_helper):
-        """post_create_backups does NOT archive weekly backups."""
-        mock_client = MagicMock()
-        mock_aws_helper.boto3_client.return_value = mock_client
-
-        engine = ShelveryEBSBackup.__new__(ShelveryEBSBackup)
-        engine.role_arn = None
-        engine.role_external_id = None
-        engine.logger = MagicMock()
-        engine.lambda_payload = None
-        engine.wait_backup_available = MagicMock(return_value=True)
-
-        weekly_br = self._make_backup_resource(BackupResource.RETENTION_WEEKLY, 'snap-weekly')
-
-        engine.post_create_backups([weekly_br])
-
-        engine.wait_backup_available.assert_not_called()
-        mock_client.modify_snapshot_tier.assert_not_called()
-
-    @patch('shelvery.ebs_backup.AwsHelper')
     @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'false'}, clear=False)
-    def test_post_create_backups_disabled_skips_monthly(self, mock_aws_helper):
-        """post_create_backups does NOT archive when feature is disabled."""
-        mock_client = MagicMock()
-        mock_aws_helper.boto3_client.return_value = mock_client
+    def test_archive_pending_backups_disabled_skips(self, mock_aws_helper):
+        engine = self._make_engine()
+        engine.get_existing_backups = MagicMock()
+        engine.archive_backup = MagicMock()
 
-        engine = ShelveryEBSBackup.__new__(ShelveryEBSBackup)
-        engine.role_arn = None
-        engine.role_external_id = None
-        engine.logger = MagicMock()
-        engine.lambda_payload = None
-        engine.wait_backup_available = MagicMock(return_value=True)
+        engine.archive_pending_backups()
 
-        monthly_br = self._make_backup_resource(BackupResource.RETENTION_MONTHLY, 'snap-monthly')
+        engine.get_existing_backups.assert_not_called()
+        engine.archive_backup.assert_not_called()
 
-        engine.post_create_backups([monthly_br])
-
-        engine.wait_backup_available.assert_not_called()
-        mock_client.modify_snapshot_tier.assert_not_called()
-
+    @patch('shelvery.ebs_backup.RuntimeConfig.get_share_with_accounts')
     @patch('shelvery.ebs_backup.AwsHelper')
     @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'true'}, clear=False)
-    def test_post_create_backups_mixed_retention_types(self, mock_aws_helper):
-        """post_create_backups only archives monthly/yearly from a mixed list."""
-        mock_client = MagicMock()
-        mock_aws_helper.boto3_client.return_value = mock_client
+    def test_archive_pending_backups_waits_for_all_share_targets(
+        self, mock_aws_helper, mock_share_accounts
+    ):
+        mock_ec2 = MagicMock()
+        mock_s3 = MagicMock()
+        mock_aws_helper.boto3_client.side_effect = lambda service, **kwargs: mock_s3 if service == 's3' else mock_ec2
 
-        engine = ShelveryEBSBackup.__new__(ShelveryEBSBackup)
-        engine.role_arn = None
-        engine.role_external_id = None
-        engine.logger = MagicMock()
-        engine.lambda_payload = None
-        engine.wait_backup_available = MagicMock(return_value=True)
+        engine = self._make_engine()
+        mock_share_accounts.return_value = ['222222222222', '333333333333']
 
-        daily_br = self._make_backup_resource(BackupResource.RETENTION_DAILY, 'snap-daily')
-        weekly_br = self._make_backup_resource(BackupResource.RETENTION_WEEKLY, 'snap-weekly')
-        monthly_br = self._make_backup_resource(BackupResource.RETENTION_MONTHLY, 'snap-monthly')
-        yearly_br = self._make_backup_resource(BackupResource.RETENTION_YEARLY, 'snap-yearly')
+        def list_side_effect(Bucket, Prefix, ContinuationToken=None):
+            if '222222222222/ebs-processed/' in Prefix:
+                return {'Contents': [{'Key': 'backups/shared/222222222222/ebs-processed/test.yaml'}]}
+            if '333333333333/ebs-processed/' in Prefix:
+                return {'Contents': []}
+            return {}
 
-        engine.post_create_backups([daily_br, weekly_br, monthly_br, yearly_br])
+        mock_s3.get_bucket_location.return_value = {'LocationConstraint': 'ap-southeast-2'}
+        mock_s3.list_objects_v2.side_effect = list_side_effect
+        mock_s3.head_object.side_effect = head_object_not_found
 
-        self.assertEqual(engine.wait_backup_available.call_count, 2)
-        calls = mock_client.modify_snapshot_tier.call_args_list
-        self.assertEqual(len(calls), 2)
-        self.assertEqual(calls[0].kwargs['SnapshotId'], 'snap-monthly')
-        self.assertEqual(calls[1].kwargs['SnapshotId'], 'snap-yearly')
+        bucket = MagicMock()
+        bucket.name = 'shelvery.data.111111111111-ap-southeast-2.base2tools'
 
+        with patch.object(ShelveryEBSBackup, '_get_data_bucket', return_value=bucket):
+            engine.archive_pending_backups()
+
+        mock_ec2.modify_snapshot_tier.assert_not_called()
+
+    @patch('shelvery.ebs_backup.RuntimeConfig.get_share_with_accounts')
     @patch('shelvery.ebs_backup.AwsHelper')
     @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'true'}, clear=False)
-    def test_post_create_backups_handles_api_error_gracefully(self, mock_aws_helper):
-        """post_create_backups logs but does not raise on archive failure."""
+    def test_archive_pending_backups_archives_when_all_targets_processed(
+        self, mock_aws_helper, mock_share_accounts
+    ):
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_snapshots.return_value = {
+            'Snapshots': [{'StorageTier': 'standard', 'State': 'completed', 'Progress': '100%'}]
+        }
+        mock_s3 = MagicMock()
+        mock_aws_helper.boto3_client.side_effect = lambda service, **kwargs: mock_s3 if service == 's3' else mock_ec2
+
+        engine = self._make_engine()
+        engine.wait_backup_available = MagicMock(return_value=True)
+        monthly_br = self._make_backup_resource(BackupResource.RETENTION_MONTHLY, 'snap-monthly')
+        mock_share_accounts.return_value = ['222222222222', '333333333333']
+
+        processed_key_a = 'backups/shared/222222222222/ebs-processed/test-backup-monthly.yaml'
+        processed_key_b = 'backups/shared/333333333333/ebs-processed/test-backup-monthly.yaml'
+
+        def list_side_effect(Bucket, Prefix, ContinuationToken=None):
+            if '222222222222/ebs-processed/' in Prefix:
+                return {'Contents': [{'Key': processed_key_a}]}
+            if '333333333333/ebs-processed/' in Prefix:
+                return {'Contents': [{'Key': processed_key_b}]}
+            return {}
+
+        mock_s3.get_bucket_location.return_value = {'LocationConstraint': 'ap-southeast-2'}
+        mock_s3.list_objects_v2.side_effect = list_side_effect
+        mock_s3.head_object.side_effect = head_object_not_found
+        mock_s3.get_object.return_value = {
+            'Body': MagicMock(read=MagicMock(return_value=b'backup-yaml'))
+        }
+
+        bucket = MagicMock()
+        bucket.name = 'shelvery.data.111111111111-ap-southeast-2.base2tools'
+
+        with patch.object(ShelveryEBSBackup, '_get_data_bucket', return_value=bucket):
+            with patch.object(ShelveryEBSBackup, '_load_backup_from_s3', return_value=monthly_br):
+                engine.archive_pending_backups()
+
+        mock_ec2.modify_snapshot_tier.assert_called_once_with(
+            SnapshotId='snap-monthly',
+            StorageTier='archive'
+        )
+        mock_s3.delete_object.assert_has_calls([
+            call(Bucket=bucket.name, Key=processed_key_a),
+            call(Bucket=bucket.name, Key=processed_key_b),
+        ], any_order=True)
+
+    @patch('shelvery.ebs_backup.AwsHelper')
+    @patch.dict(os.environ, {'shelvery_enable_ebs_archive_pulled': 'true'}, clear=False)
+    def test_post_pull_backups_handles_api_error_gracefully(self, mock_aws_helper):
         mock_client = MagicMock()
         mock_client.modify_snapshot_tier.side_effect = Exception("API Error")
         mock_aws_helper.boto3_client.return_value = mock_client
-
-        engine = ShelveryEBSBackup.__new__(ShelveryEBSBackup)
-        engine.role_arn = None
-        engine.role_external_id = None
-        engine.logger = MagicMock()
-        engine.lambda_payload = None
+        engine = self._make_engine()
         engine.wait_backup_available = MagicMock(return_value=True)
-
         monthly_br = self._make_backup_resource(BackupResource.RETENTION_MONTHLY, 'snap-fail')
 
-        # Should not raise
-        engine.post_create_backups([monthly_br])
+        engine.post_pull_backups([monthly_br])
 
         engine.logger.exception.assert_called_once()
 
     @patch('shelvery.ebs_backup.AwsHelper')
     @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'true'}, clear=False)
-    def test_post_create_backups_per_resource_tag_override(self, mock_aws_helper):
-        """Archive is skipped for a resource that has the tag set to false."""
-        mock_client = MagicMock()
-        mock_aws_helper.boto3_client.return_value = mock_client
+    def test_should_archive_source_respects_resource_tag_override(self, mock_aws_helper):
+        engine = self._make_engine()
+        monthly_br = self._make_backup_resource(
+            BackupResource.RETENTION_MONTHLY,
+            tags={'shelvery:config:shelvery_enable_ebs_archive': 'false'},
+        )
 
-        engine = ShelveryEBSBackup.__new__(ShelveryEBSBackup)
-        engine.role_arn = None
-        engine.role_external_id = None
-        engine.logger = MagicMock()
-        engine.lambda_payload = None
-        engine.wait_backup_available = MagicMock(return_value=True)
+        self.assertFalse(engine._should_archive_source(monthly_br))
 
-        monthly_br = self._make_backup_resource(BackupResource.RETENTION_MONTHLY, 'snap-override')
-        monthly_br.entity_resource.tags = {
-            'shelvery:config:shelvery_enable_ebs_archive': 'false'
-        }
+    @patch.dict(os.environ, {'shelvery_enable_ebs_archive': 'true'}, clear=False)
+    def test_monthly_backups_remain_shareable_when_archive_enabled(self):
+        """Monthly/yearly backups must still be shared so databunker can pull before archive."""
+        engine = self._make_engine()
+        monthly_br = self._make_backup_resource(BackupResource.RETENTION_MONTHLY)
 
-        engine.post_create_backups([monthly_br])
-
-        engine.wait_backup_available.assert_not_called()
-        mock_client.modify_snapshot_tier.assert_not_called()
+        self.assertTrue(engine.is_backup_shareable(monthly_br))
 
 
 if __name__ == '__main__':

--- a/template.yaml
+++ b/template.yaml
@@ -14,6 +14,9 @@ Parameters:
   PullSharedBackupsSchedule:
     Type: String
     Default: "0 2 ? * * *"
+  ArchivePendingBackupsSchedule:
+    Type: String
+    Default: "0 3 ? * * *"
   S3BackupSchedule:
     Type: String
     Default: "0 1 ? * * *"
@@ -72,7 +75,14 @@ Parameters:
     Type: String
     Default: ''
   ShelveryEnableEbsArchive:
-    Description: Enable archiving monthly/yearly EBS snapshots to archive tier
+    Description: Enable archiving monthly/yearly EBS snapshots to archive tier in source account after pull
+    Type: String
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Default: 'false'
+  ShelveryEnableEbsArchivePulled:
+    Description: Enable archiving monthly/yearly EBS snapshots in databunker account after pull
     Type: String
     AllowedValues:
       - 'true'
@@ -151,6 +161,7 @@ Resources:
           shelvery_copy_kms_key_id: !Ref ShelveryCopyKmsKeyId
           shelvery_reencrypt_kms_key_id: !Ref ShelveryReencryptKmsKeyId
           shelvery_enable_ebs_archive: !Ref ShelveryEnableEbsArchive
+          shelvery_enable_ebs_archive_pulled: !Ref ShelveryEnableEbsArchivePulled
 
       Events:
 
@@ -243,6 +254,12 @@ Resources:
           Properties:
             Schedule: !Sub cron(${PullSharedBackupsSchedule})
             Input: '{"backup_type":"docdb","action":"pull_shared_backups"}'
+
+        ArchiveEbs:
+          Type: Schedule
+          Properties:
+            Schedule: !Sub cron(${ArchivePendingBackupsSchedule})
+            Input: '{"backup_type":"ebs","action":"archive_pending_backups"}'
 
       Policies:
         - Version: "2012-10-17"

--- a/template.yaml
+++ b/template.yaml
@@ -71,6 +71,13 @@ Parameters:
     Description: During the share task, Kms key id to encrypt snapshots with
     Type: String
     Default: ''
+  ShelveryEnableEbsArchive:
+    Description: Enable archiving monthly/yearly EBS snapshots to archive tier
+    Type: String
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Default: 'false'
 
 Resources:
 
@@ -122,7 +129,7 @@ Resources:
       Tags:
         Name: Shelvery
         CreatedBy: Shelvery
-        ShelveryVersion: 0.9.13
+        ShelveryVersion: 0.9.14
 
       Environment:
         Variables:
@@ -143,6 +150,7 @@ Resources:
           shelvery_encrypt_copy: !Ref ShelveryEncryptCopy
           shelvery_copy_kms_key_id: !Ref ShelveryCopyKmsKeyId
           shelvery_reencrypt_kms_key_id: !Ref ShelveryReencryptKmsKeyId
+          shelvery_enable_ebs_archive: !Ref ShelveryEnableEbsArchive
 
       Events:
 
@@ -276,6 +284,7 @@ Resources:
                 - ec2:ModifySnapshotAttribute
                 - ec2:ResetSnapshotAttribute
                 - ec2:DeleteSnapshot
+                - ec2:ModifySnapshotTier
                 - ec2:DescribeTags
                 - ec2:CreateTags
                 - ec2:DeleteTags


### PR DESCRIPTION
## Changelog
- Added archiving logic for monthly & yearly EBS snapshots
- Added parameter `ShelveryEnableEbsArchive` to enable/disable archive logic, defaults to False for opt-in behaviour.

Tested and works as expected.
First snapshot is with parameter set to False/default, as such no archiving occurs.
Second snapshot is after parameter is set to true, as such the tier is set to archive.
<img width="1074" height="107" alt="Screenshot 2026-05-07 at 1 48 46 pm" src="https://github.com/user-attachments/assets/6ff0ec81-71b7-4d2f-aae5-dfe95b56e925" />

